### PR TITLE
Add rich dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,5 +35,7 @@ classifiers =
 
 [options]
 packages = rich_rst
-install_requires = docutils
+install_requires =
+  docutils
+  rich >=12.0.0
 python_requires = >=3.6


### PR DESCRIPTION
## 📑 Description

`rich-rst` depends on `rich`, so it should be listed in the requirements.