### PR TITLE
fix too many arguments to unpack when visiting block quote.

### DIFF
--- a/rich_rst/__init__.py
+++ b/rich_rst/__init__.py
@@ -408,7 +408,7 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
         try:
             paragraph, attribution = node.children
         except ValueError:
-            paragraph ,= node.children
+            paragraph = node.children[0]
             self.renderables.append(
                 Text("    ")
                 + Text(paragraph.astext().replace('\n', ' '), style=text_style)


### PR DESCRIPTION
Without this change, I frequently run into:

```
ValueError: too many values to unpack (expected 1)
```