### PR TITLE
No trailing newline

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,42 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    timeout-minutes: 45
+    defaults:
+      run:
+        shell: bash
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest] #, macos-latest, windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install library
+        run: |
+          pip install -e .
+          pip install pytest pytest-coverage
+
+      - name: Run tests
+        run: |
+          python -m pytest --cov=rich_rst --cov-report term --cov-report xml --junitxml=testresults.xml
+          coverage report

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 
 # End of https://www.toptal.com/developers/gitignore/api/python
 .history/**
+
+*_actual.html
+*.DS_Store

--- a/rich_rst/__init__.py
+++ b/rich_rst/__init__.py
@@ -601,6 +601,9 @@ class RestructuredText(JupyterMixin):
         )
         document.walkabout(visitor)
 
+        if visitor.renderables and isinstance(visitor.renderables[-1], Text):
+            visitor.renderables[-1].rstrip()
+            visitor.renderables[-1].end = "\n"
         for renderable in visitor.renderables:
             yield from console.render(renderable, options)
         if self.log_errors and visitor.errors:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,52 @@
+import pytest
+from rich_rst import RestructuredText
+from pathlib import Path
+from rich.console import Console
+from rich.terminal_theme import TerminalTheme
+
+test_vectors_path = Path("tests/test_vectors")
+rst_paths = sorted(str(x) for x in test_vectors_path.glob("*.rst"))
+
+
+def render_to_html(rst):
+    DRACULA_TERMINAL_THEME = TerminalTheme(
+        (40, 42, 54),
+        (248, 248, 242),
+        [
+            (40, 42, 54),
+            (255, 85, 85),
+            (80, 250, 123),
+            (241, 250, 140),
+            (189, 147, 249),
+            (255, 121, 198),
+            (139, 233, 253),
+            (255, 255, 255),
+        ],
+        [
+            (40, 42, 54),
+            (255, 85, 85),
+            (80, 250, 123),
+            (241, 250, 140),
+            (189, 147, 249),
+            (255, 121, 198),
+            (139, 233, 253),
+            (255, 255, 255),
+        ],
+    )
+    console = Console(force_terminal=True, width=120, record=True)
+    console.print(rst)
+    return console.export_html(theme=DRACULA_TERMINAL_THEME)
+
+
+@pytest.mark.parametrize("rst_path", rst_paths)
+def test_main(rst_path):
+    rst_path = Path(rst_path)
+    actual_html_path = rst_path.parent / (rst_path.stem + "_actual.html")
+    expected_html_path = rst_path.parent / (rst_path.stem + "_expected.html")
+
+    rst = RestructuredText(rst_path.read_text(), show_errors=True)
+    actual_html = render_to_html(rst)
+    actual_html_path.write_text(actual_html)
+
+    expected_html = expected_html_path.read_text()
+    assert expected_html == actual_html

--- a/tests/test_vectors/directives.rst
+++ b/tests/test_vectors/directives.rst
@@ -1,0 +1,2037 @@
+=============================
+ reStructuredText Directives
+=============================
+:Author: David Goodger
+:Contact: docutils-develop@lists.sourceforge.net
+:Revision: $Revision: 8959 $
+:Date: $Date: 2022-01-21 14:45:42 +0100 (Fr, 21. Jan 2022) $
+:Copyright: This document has been placed in the public domain.
+
+.. contents::
+   :depth: 2
+
+This document describes the directives implemented in the reference
+reStructuredText parser.
+
+Directives have the following syntax::
+
+    +-------+-------------------------------+
+    | ".. " | directive type "::" directive |
+    +-------+ block                         |
+            |                               |
+            +-------------------------------+
+
+Directives begin with an explicit markup start (two periods and a
+space), followed by the directive type and two colons (collectively,
+the "directive marker").  The directive block begins immediately after
+the directive marker, and includes all subsequent indented lines.  The
+directive block is divided into arguments, options (a field list), and
+content (in that order), any of which may appear.  See the Directives_
+section in the `reStructuredText Markup Specification`_ for syntax
+details.
+
+Descriptions below list "doctree elements" (document tree element
+names; XML DTD generic identifiers) corresponding to individual
+directives.  For details on the hierarchy of elements, please see `The
+Docutils Document Tree`_ and the `Docutils Generic DTD`_ XML document
+type definition.  For directive implementation details, see `Creating
+reStructuredText Directives`_.
+
+.. _Directives: restructuredtext.html#directives
+.. _reStructuredText Markup Specification: restructuredtext.html
+.. _The Docutils Document Tree: ../doctree.html
+.. _Docutils Generic DTD: ../docutils.dtd
+.. _Creating reStructuredText Directives:
+   ../../howto/rst-directives.html
+
+
+-------------
+ Admonitions
+-------------
+
+.. From Webster's Revised Unabridged Dictionary (1913) [web1913]:
+   Admonition
+      Gentle or friendly reproof; counseling against a fault or
+      error; expression of authoritative advice; friendly caution
+      or warning.
+
+      Syn: {Admonition}, {Reprehension}, {Reproof}.
+
+      Usage: Admonition is prospective, and relates to moral delinquencies;
+             its object is to prevent further transgression.
+
+.. _attention:
+.. _caution:
+.. _danger:
+.. _error:
+.. _hint:
+.. _important:
+.. _note:
+.. _tip:
+.. _warning:
+
+Specific Admonitions
+====================
+
+:Directive Types: "attention", "caution", "danger", "error", "hint",
+                  "important", "note", "tip", "warning", "admonition"
+:Doctree Elements: attention, caution, danger, error, hint, important,
+                   note, tip, warning, admonition_, title_
+:Directive Arguments: None.
+:Directive Options: class_, name_
+:Directive Content: Interpreted as body elements.
+
+Admonitions are specially marked "topics" that can appear anywhere an
+ordinary body element can.  They contain arbitrary body elements.
+Typically, an admonition is rendered as an offset block in a document,
+sometimes outlined or shaded, with a title matching the admonition
+type.  For example::
+
+    .. DANGER::
+       Beware killer rabbits!
+
+This directive might be rendered something like this::
+
+    +------------------------+
+    |        !DANGER!        |
+    |                        |
+    | Beware killer rabbits! |
+    +------------------------+
+
+The following admonition directives have been implemented:
+
+- attention
+- caution
+- danger
+- error
+- hint
+- important
+- note
+- tip
+- warning
+
+Any text immediately following the directive indicator (on the same
+line and/or indented on following lines) is interpreted as a directive
+block and is parsed for normal body elements.  For example, the
+following "note" admonition directive contains one paragraph and a
+bullet list consisting of two list items::
+
+    .. note:: This is a note admonition.
+       This is the second line of the first paragraph.
+
+       - The note contains all indented body elements
+         following.
+       - It includes this bullet list.
+
+
+Generic Admonition
+==================
+
+:Directive Type: "admonition"
+:Doctree Elements: admonition_, title_
+:Directive Arguments: One, required (admonition title)
+:Directive Options: class_, name_
+:Directive Content: Interpreted as body elements.
+
+This is a generic, titled admonition.  The title may be anything the
+author desires.
+
+The author-supplied title is also used as a `"classes"`_ attribute value
+after being converted into a valid identifier form (down-cased;
+non-alphanumeric characters converted to single hyphens; "admonition-"
+prefixed).  For example, this admonition::
+
+    .. admonition:: And, by the way...
+
+       You can make up your own admonition too.
+
+becomes the following document tree (pseudo-XML)
+
+.. code-block:: xml
+
+    <document source="test data">
+        <admonition classes="admonition-and-by-the-way">
+            <title>
+                And, by the way...
+            <paragraph>
+                You can make up your own admonition too.
+
+The class_ option overrides the computed `"classes"`_ attribute
+value.
+
+
+--------
+ Images
+--------
+
+There are two image directives: "image" and "figure".
+
+It is up to the author to ensure compatibility of the image data format
+with the output format or user agent (LaTeX__ engine, `HTML5 browser`__,
+ODT, ...). The following, non exhaustive table provides an overview
+
+.. [#] The html5 writer uses the ``<video>`` tag if the image URI points
+       to a file with an extension matching one of the listed video formats
+       (since Docutils 0.17).
+
+.. [#] The html4 writer uses an ``<object>`` tag for SVG images for better
+       compatibility with older browsers.
+
+.. [#] When compiling with ``pdflatex``, ``xelatex``, or ``lualatex``.
+       The original ``latex`` engine supports only the EPS image format.
+       Some build systems, e.g. rubber_ support additional formats via
+       on-the-fly image conversion.
+
+__ ../../user/latex.html#image-inclusion
+__ https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types
+.. _rubber: https://github.com/petrhosek/rubber
+
+Image
+=====
+
+:Directive Type: "image"
+:Doctree Element: image_
+:Directive Arguments: One, required (image URI).
+:Directive Options: Possible (see below).
+:Directive Content: None.
+
+An "image" is a simple picture::
+
+    .. image:: picture.png
+
+Inline images can be defined with an "image" directive in a `substitution
+definition`_
+
+The URI for the image source file is specified in the directive
+argument.  As with hyperlink targets, the image URI may begin on the
+same line as the explicit markup start and target name, or it may
+begin in an indented text block immediately following, with no
+intervening blank lines.  If there are multiple lines in the link
+block, they are stripped of leading and trailing whitespace and joined
+together.
+
+Optionally, the image link block may contain a flat field list, the
+_`image options`.  For example::
+
+    .. image:: picture.jpeg
+       :height: 100px
+       :width: 200 px
+       :scale: 50 %
+       :alt: alternate text
+       :align: right
+
+The following options are recognized:
+
+``alt`` : text
+    Alternate text: a short description of the image, displayed by
+    applications that cannot display images, or spoken by applications
+    for visually impaired users.
+
+``height`` : `length`_
+    The desired height of the image.
+    Used to reserve space or scale the image vertically.  When the "scale"
+    option is also specified, they are combined.  For example, a height of
+    200px and a scale of 50 is equivalent to a height of 100px with no scale.
+
+``width`` : `length`_ or `percentage`_ of the current line width
+    The width of the image.
+    Used to reserve space or scale the image horizontally.  As with "height"
+    above, when the "scale" option is also specified, they are combined.
+
+``scale`` : integer percentage (the "%" symbol is optional)
+    The uniform scaling factor of the image.  The default is "100Â %", i.e.
+    no scaling.
+
+    If no "height" or "width" options are specified, the `Python
+    Imaging Library` (PIL/Pillow_) may be used to determine them, if
+    it is installed and the image file is available.
+
+``align`` : "top", "middle", "bottom", "left", "center", or "right"
+    The alignment of the image, equivalent to the HTML ``<img>`` tag's
+    deprecated "align" attribute or the corresponding "vertical-align" and
+    "text-align" CSS properties.
+    The values "top", "middle", and "bottom"
+    control an image's vertical alignment (relative to the text
+    baseline); they are only useful for inline images (substitutions).
+    The values "left", "center", and "right" control an image's
+    horizontal alignment, allowing the image to float and have the
+    text flow around it.  The specific behavior depends upon the
+    browser or rendering software used.
+
+``target`` : text (URI or reference name)
+    Makes the image into a hyperlink reference ("clickable").  The
+    option argument may be a URI (relative or absolute), or a
+    `reference name`_ with underscore suffix (e.g. ```a name`_``).
+
+and the common options class_ and name_.
+
+
+Figure
+======
+
+:Directive Type: "figure"
+:Doctree Elements: figure_, image_, caption_, legend_
+:Directive Arguments: One, required (image URI).
+:Directive Options: Possible (see below).
+:Directive Content: Interpreted as the figure caption and an optional
+                    legend.
+
+A "figure" consists of image_ data (including `image options`_), an optional
+caption (a single paragraph), and an optional legend (arbitrary body
+elements). For page-based output media, figures might float to a different
+position if this helps the page layout.
+::
+
+    .. figure:: picture.png
+       :scale: 50 %
+       :alt: map to buried treasure
+
+       This is the caption of the figure (a simple paragraph).
+
+There must be blank lines before the caption paragraph and before the
+legend.  To specify a legend without a caption, use an empty comment
+("..") in place of the caption.
+
+The "figure" directive supports all of the options of the "image"
+directive (see `image options`_ above). These options (except
+"align") are passed on to the contained image.
+
+``align`` : "left", "center", or "right"
+    The horizontal alignment of the figure, allowing the image to
+    float and have the text flow around it.  The specific behavior
+    depends upon the browser or rendering software used.
+
+In addition, the following options are recognized:
+
+``figwidth`` : "image", length_, or percentage_ of current line width
+    The width of the figure.
+    Limits the horizontal space used by the figure.
+    A special value of "image" is allowed, in which case the
+    included image's actual width is used (requires the `Python Imaging
+    Library`_). If the image file is not found or the required software is
+    unavailable, this option is ignored.
+
+    Sets the "width" attribute of the "figure" doctree element.
+
+    This option does not scale the included image; use the "width"
+    `image`_ option for that.
+
+``figclass`` : text
+    Set a `"classes"`_ attribute value on the figure element.  See the
+    class_ directive below.
+
+.. _Python Imaging Library:
+.. _Pillow: https://pypi.org/project/Pillow/
+
+
+---------------
+ Body Elements
+---------------
+
+Topic
+=====
+
+:Directive Type: "topic"
+:Doctree Element: topic_
+:Directive Arguments: One, required (topic title).
+:Directive Options: class_, name_
+:Directive Content: Interpreted as the topic body.
+
+A topic is like a block quote with a title, or a self-contained
+section with no subsections.  Use the "topic" directive to indicate a
+self-contained idea that is separate from the flow of the document.
+Topics may occur anywhere a section or transition may occur.  Body
+elements and topics may not contain nested topics.
+
+The directive's sole argument is interpreted as the topic title; the
+next line must be blank.  All subsequent lines make up the topic body,
+interpreted as body elements.  For example::
+
+    .. topic:: Topic Title
+
+        Subsequent indented lines comprise
+        the body of the topic, and are
+        interpreted as body elements.
+
+
+Sidebar
+=======
+
+:Directive Type: "sidebar"
+:Doctree Element: sidebar_
+:Directive Arguments: One, optional (sidebar title).
+:Directive Options: Possible (see below).
+:Directive Content: Interpreted as the sidebar body.
+
+Sidebars are like miniature, parallel documents that occur inside
+other documents, providing related or reference material.  A sidebar
+is typically offset by a border and "floats" to the side of the page;
+the document's main text may flow around it.  Sidebars can also be
+likened to super-footnotes; their content is outside of the flow of
+the document's main text.
+
+Sidebars may occur anywhere a section or transition may occur.  Body
+elements (including sidebars) may not contain nested sidebars.
+
+The directive's sole argument is interpreted as the sidebar title,
+which may be followed by a subtitle option (see below); the next line
+must be blank.  All subsequent lines make up the sidebar body,
+interpreted as body elements.  For example::
+
+    .. sidebar:: Optional Sidebar Title
+       :subtitle: Optional Sidebar Subtitle
+
+       Subsequent indented lines comprise
+       the body of the sidebar, and are
+       interpreted as body elements.
+
+The following options are recognized:
+
+``subtitle`` : text
+    The sidebar's subtitle.
+
+and the common options class_ and name_.
+
+
+Line Block
+==========
+
+.. admonition:: Deprecated
+
+   The "line-block" directive is deprecated.  Use the `line block
+   syntax`_ instead.
+
+   .. _line block syntax: restructuredtext.html#line-blocks
+
+:Directive Type: "line-block"
+:Doctree Element: line_block_
+:Directive Arguments: None.
+:Directive Options: class_, name_
+:Directive Content: Becomes the body of the line block.
+
+The "line-block" directive constructs an element where line breaks and
+initial indentation is significant and inline markup is supported.  It
+is equivalent to a `parsed literal block`_ with different rendering:
+typically in an ordinary serif typeface instead of a
+typewriter/monospaced face, and not automatically indented.  (Have the
+line-block directive begin a block quote to get an indented line
+block.)  Line blocks are useful for address blocks and verse (poetry,
+song lyrics), where the structure of lines is significant.  For
+example, here's a classic::
+
+    "To Ma Own Beloved Lassie: A Poem on her 17th Birthday", by
+    Ewan McTeagle (for Lassie O'Shea):
+
+        .. line-block::
+
+            Lend us a couple of bob till Thursday.
+            I'm absolutely skint.
+            But I'm expecting a postal order and I can pay you back
+                as soon as it comes.
+            Love, Ewan.
+
+
+
+.. _parsed-literal:
+
+Parsed Literal Block
+====================
+
+:Directive Type: "parsed-literal"
+:Doctree Element: literal_block_
+:Directive Arguments: None.
+:Directive Options: class_, name_
+:Directive Content: Becomes the body of the literal block.
+
+Unlike an ordinary literal block, the "parsed-literal" directive
+constructs a literal block where the text is parsed for inline markup.
+It is equivalent to a `line block`_ with different rendering:
+typically in a typewriter/monospaced typeface, like an ordinary
+literal block.  Parsed literal blocks are useful for adding hyperlinks
+to code examples.
+
+However, care must be taken with the text, because inline markup is
+recognized and there is no protection from parsing.  Backslash-escapes
+may be necessary to prevent unintended parsing.  And because the
+markup characters are removed by the parser, care must also be taken
+with vertical alignment.  Parsed "ASCII art" is tricky, and extra
+whitespace may be necessary.
+
+For example, all the element names in this content model are links::
+
+    .. parsed-literal::
+
+       ( (title_, subtitle_?)?,
+         decoration_?,
+         (docinfo_, transition_?)?,
+         `%structure.model;`_ )
+
+Code
+====
+
+:Directive Type: "code"
+:Doctree Element: literal_block_, `inline elements`_
+:Directive Arguments: One, optional (formal language).
+:Directive Options: name, class, number-lines.
+:Directive Content: Becomes the body of the literal block.
+:Configuration Setting: syntax_highlight_.
+
+The "code" directive constructs a literal block. If the code language is
+specified, the content is parsed by the Pygments_ syntax highlighter and
+tokens are stored in nested `inline elements`_ with class arguments
+according to their syntactic category. The actual highlighting requires
+a style-sheet (e.g. one `generated by Pygments`__, see the
+`sandbox/stylesheets`__ for examples).
+
+The parsing can be turned off with the syntax_highlight_ configuration
+setting and command line option or by specifying the language as class_
+option instead of directive argument. This also avoids warnings
+when Pygments_ is not installed or the language is not in the
+`supported languages and markup formats`_.
+
+For inline code, use the `"code" role`_.
+
+__ https://pygments.org/docs/cmdline/#generating-styles
+__ https://docutils.sourceforge.io/sandbox/stylesheets/
+.. _Pygments: https://pygments.org/
+.. _syntax_highlight: ../../user/config.html#syntax-highlight
+.. _supported languages and markup formats: https://pygments.org/languages/
+.. _"code" role: roles.html#code
+
+
+The following options are recognized:
+
+``number-lines`` : [integer] (start line number)
+    Precede every line with a line number.
+    The optional argument is the number of the first line (default 1).
+
+and the common options class_ and name_.
+
+Example::
+
+  The content of the following directive ::
+
+    .. code:: python
+
+      def my_function():
+          "just a test"
+          print 8/2
+
+  is parsed and marked up as Python source code.
+
+
+Math
+====
+
+:Directive Type: "math"
+:Doctree Element: math_block_
+:Directive Arguments: None.
+:Directive Options: class_, name_
+:Directive Content: Becomes the body of the math block.
+                    (Content blocks separated by a blank line are put in
+                    adjacent math blocks.)
+:Configuration Setting: math_output_
+
+The "math" directive inserts blocks with mathematical content
+(display formulas, equations) into the document. The input format is
+`LaTeX math syntax`_ with support for Unicode symbols, for example::
+
+  .. math::
+
+    Î±_t(i) = P(O_1, O_2, â€¦ O_t, q_t = S_i Î»)
+
+Support is limited to a subset of *LaTeX math* by the conversion
+required for many output formats.  For HTML, the `math_output`_
+configuration setting (or the corresponding ``--math-output``
+command line option) select between alternative output formats with
+different subsets of supported elements. If a writer does not
+support math typesetting, the content is inserted verbatim.
+
+For inline formulas, use the `"math" role`_.
+
+.. _LaTeX math syntax: ../../ref/rst/mathematics.html
+.. _"math" role: roles.html#math
+.. _math_output: ../../user/config.html#math-output
+
+
+Rubric
+======
+
+:Directive Type: "rubric"
+:Doctree Element: rubric_
+:Directive Arguments: One, required (rubric text).
+:Directive Options: class_, name_
+:Directive Content: None.
+
+..
+
+     rubric n. 1. a title, heading, or the like, in a manuscript,
+     book, statute, etc., written or printed in red or otherwise
+     distinguished from the rest of the text. ...
+
+     -- Random House Webster's College Dictionary, 1991
+
+The "rubric" directive inserts a "rubric" element into the document
+tree.  A rubric is like an informal heading that doesn't correspond to
+the document's structure.
+
+
+Epigraph
+========
+
+:Directive Type: "epigraph"
+:Doctree Element: block_quote_
+:Directive Arguments: None.
+:Directive Options: None.
+:Directive Content: Interpreted as the body of the block quote.
+
+An epigraph is an apposite (suitable, apt, or pertinent) short
+inscription, often a quotation or poem, at the beginning of a document
+or section.
+
+The "epigraph" directive produces an "epigraph"-class block quote.
+For example, this input::
+
+     .. epigraph::
+
+        No matter where you go, there you are.
+
+        -- Buckaroo Banzai
+
+becomes this document tree fragment::
+
+    <block_quote classes="epigraph">
+        <paragraph>
+            No matter where you go, there you are.
+        <attribution>
+            Buckaroo Banzai
+
+
+Highlights
+==========
+
+:Directive Type: "highlights"
+:Doctree Element: block_quote_
+:Directive Arguments: None.
+:Directive Options: None.
+:Directive Content: Interpreted as the body of the block quote.
+
+Highlights summarize the main points of a document or section, often
+consisting of a list.
+
+The "highlights" directive produces a "highlights"-class block quote.
+See Epigraph_ above for an analogous example.
+
+
+Pull-Quote
+==========
+
+:Directive Type: "pull-quote"
+:Doctree Element: block_quote_
+:Directive Arguments: None.
+:Directive Options: None.
+:Directive Content: Interpreted as the body of the block quote.
+
+A pull-quote is a small selection of text "pulled out and quoted",
+typically in a larger typeface.  Pull-quotes are used to attract
+attention, especially in long articles.
+
+The "pull-quote" directive produces a "pull-quote"-class block quote.
+See Epigraph_ above for an analogous example.
+
+
+Compound Paragraph
+==================
+
+:Directive Type: "compound"
+:Doctree Element: compound_
+:Directive Arguments: None.
+:Directive Options: class_, name_
+:Directive Content: Interpreted as body elements.
+
+The "compound" directive is used to create a compound paragraph, which
+is a single logical paragraph containing multiple physical body
+elements such as simple paragraphs, literal blocks, tables, lists,
+etc., instead of directly containing text and inline elements.  For
+example::
+
+    .. compound::
+
+       The 'rm' command is very dangerous.  If you are logged
+       in as root and enter ::
+
+           cd /
+           rm -rf *
+
+       you will erase the entire contents of your file system.
+
+In the example above, a literal block is "embedded" within a sentence
+that begins in one physical paragraph and ends in another.
+
+.. note::
+
+   The "compound" directive is *not* a generic block-level container
+   like HTML's ``<div>`` element.  Do not use it only to group a
+   sequence of elements, or you may get unexpected results.
+
+   If you need a generic block-level container, please use the
+   container_ directive, described below.
+
+Compound paragraphs are typically rendered as multiple distinct text
+blocks, with the possibility of variations to emphasize their logical
+unity:
+
+* If paragraphs are rendered with a first-line indent, only the first
+  physical paragraph of a compound paragraph should have that indent
+  -- second and further physical paragraphs should omit the indents;
+* vertical spacing between physical elements may be reduced;
+* and so on.
+
+
+Container
+=========
+
+:Directive Type: "container"
+:Doctree Element: `container <container element_>`__
+:Directive Arguments: One or more, optional (class names).
+:Directive Options: name_
+:Directive Content: Interpreted as body elements.
+
+The "container" directive surrounds its contents (arbitrary body
+elements) with a generic block-level "container" element.  Combined
+with the optional "classes_" attribute argument(s), this is an
+extension mechanism for users & applications.  For example::
+
+    .. container:: custom
+
+       This paragraph might be rendered in a custom way.
+
+Parsing the above results in the following pseudo-XML
+
+.. code-block:: xml
+
+    <container classes="custom">
+        <paragraph>
+            This paragraph might be rendered in a custom way.
+
+The "container" directive is the equivalent of HTML's ``<div>``
+element.  It may be used to group a sequence of elements for user- or
+application-specific purposes.
+
+
+
+--------
+ Tables
+--------
+
+Formal tables need more structure than the reStructuredText syntax
+supplies.  Tables may be given titles with the table_ directive.
+Sometimes reStructuredText tables are inconvenient to write, or table
+data in a standard format is readily available.  The csv-table_
+directive supports CSV data.
+
+
+Table
+=====
+
+:Directive Type: "table"
+:Doctree Element: table_
+:Directive Arguments: One, optional (table title).
+:Directive Options: Possible (see below).
+:Directive Content: A normal `reStructuredText table`_.
+
+The "table" directive is used to associate a
+title with a table or specify options, e.g.::
+
+    .. table:: Truth table for "not"
+       :widths: auto
+
+       =====  =====
+         A    not A
+       =====  =====
+       False  True
+       True   False
+       =====  =====
+
+The following options are recognized:
+
+``align`` : "left", "center", or "right"
+    The horizontal alignment of the table (new in Docutils 0.13).
+
+``width`` : `length`_ or `percentage`_
+    Sets the width of the table to the specified length or percentage
+    of the line width.  If omitted, the renderer determines the width
+    of the table based on its contents or the column ``widths``.
+
+    .. _column-widths:
+
+``widths`` : "auto", "grid", or a list of integers
+    A list of relative column widths.
+    The default is the width of the input columns (in characters).
+
+    *"auto"* delegates the determination of column widths to the backend
+    (LaTeX, the HTML browser, ...).
+
+    *"grid"* restores the default, overriding a `table_style`_ or class
+    value "colwidths-auto".
+
+Plus the common options class_ and name_.
+
+.. _reStructuredText table: restructuredtext.html#tables
+.. _table_style: ../../user/config.html#table-style
+
+
+.. _csv-table:
+
+CSV Table
+=========
+
+:Directive Type: "csv-table"
+:Doctree Element: table_
+:Directive Arguments: One, optional (table title).
+:Directive Options: Possible (see below).
+:Directive Content: A CSV (comma-separated values) table.
+
+.. WARNING::
+
+   The "csv-table" directive's ":file:" and ":url:" options represent
+   a potential security holes.  They can be disabled with the
+   "file_insertion_enabled_" runtime setting.
+
+The "csv-table" directive is used to create a table from CSV
+(comma-separated values) data.  CSV is a common data format generated
+by spreadsheet applications and commercial databases.  The data may be
+internal (an integral part of the document) or external (a separate
+file).
+
+* Block markup and inline markup within cells is supported.  Line ends
+  are recognized within cells.
+
+* There is no support for checking that the number of columns in each
+  row is the same. The directive automatically adds empty entries at
+  the end of short rows.
+
+  .. Add "strict" option to verify input?
+
+Example::
+
+    .. csv-table:: Frozen Delights!
+       :header: "Treat", "Quantity", "Description"
+       :widths: 15, 10, 30
+
+       "Albatross", 2.99, "On a stick!"
+       "Crunchy Frog", 1.49, "If we took the bones out, it wouldn't be
+       crunchy, now would it?"
+       "Gannet Ripple", 1.99, "On a stick!"
+
+The following options are recognized:
+
+``align`` : "left", "center", or "right"
+    The horizontal alignment of the table. (New in Docutils 0.13)
+
+``delim`` : char | "tab" | "space" [#whitespace-delim]_
+    A one-character string\ [#ASCII-char]_ used to separate fields.
+    Defaults to ``,`` (comma).  May be specified as a Unicode code
+    point; see the unicode_ directive for syntax details.
+
+``encoding`` : string
+    The text encoding of the external CSV data (file or URL).
+    Defaults to the document's input_encoding_.
+
+``escape`` : char
+    A one-character\ [#ASCII-char]_ string used to escape the
+    delimiter or quote characters.  May be specified as a Unicode
+    code point; see the unicode_ directive for syntax details.  Used
+    when the delimiter is used in an unquoted field, or when quote
+    characters are used within a field.  The default is to double-up
+    the character, e.g. "He said, ""Hi!"""
+
+    .. Add another possible value, "double", to explicitly indicate
+       the default case?
+
+``file`` : string (newlines removed)
+    The local filesystem path to a CSV data file.
+
+``header`` : CSV data
+    Supplemental data for the table header, added independently of and
+    before any ``header-rows`` from the main CSV data.  Must use the
+    same CSV format as the main CSV data.
+
+``header-rows`` : integer
+    The number of rows of CSV data to use in the table header.
+    Defaults to 0.
+
+``keepspace`` : flag (empty)
+    Treat whitespace immediately following the delimiter as
+    significant.  The default is to ignore such whitespace.
+
+``quote`` : char
+    A one-character string\ [#ASCII-char]_ used to quote elements
+    containing the delimiter or which start with the quote
+    character.  Defaults to ``"`` (quote).  May be specified as a
+    Unicode code point; see the unicode_ directive for syntax
+    details.
+
+``stub-columns`` : integer
+    The number of table columns to use as stubs (row titles, on the
+    left).  Defaults to 0.
+
+``url`` : string (whitespace removed)
+    An Internet URL reference to a CSV data file.
+
+``widths`` : integer [integer...] or "auto"
+    A list of relative column widths.
+    The default is equal-width columns (100%/#columns).
+
+    "auto" delegates the determination of column widths to the backend
+    (LaTeX, the HTML browser, ...).
+
+``width`` : `length`_ or `percentage`_
+    Sets the width of the table to the specified length or percentage
+    of the line width.  If omitted, the renderer determines the width
+    of the table based on its contents or the column ``widths``.
+
+and the common options class_ and name_.
+
+.. [#whitespace-delim] Whitespace delimiters are supported only for external
+   CSV files.
+
+.. [#ASCII-char] With PythonÂ 2, the values for the ``delimiter``,
+   ``quote``, and ``escape`` options must be ASCII characters. (The csv
+   module does not support Unicode and all non-ASCII characters are
+   encoded as multi-byte utf-8 string). This limitation does not exist
+   under PythonÂ 3.
+
+
+List Table
+==========
+
+:Directive Type: "list-table"
+:Doctree Element: table_
+:Directive Arguments: One, optional (table title).
+:Directive Options: Possible (see below).
+:Directive Content: A uniform two-level bullet list.
+
+(This is an initial implementation; `further ideas`__ may be implemented
+in the future.)
+
+__ ../../dev/rst/alternatives.html#list-driven-tables
+
+The "list-table" directive is used to create a table from data in a
+uniform two-level bullet list.  "Uniform" means that each sublist
+(second-level list) must contain the same number of list items.
+
+Example::
+
+    .. list-table:: Frozen Delights!
+       :widths: 15 10 30
+       :header-rows: 1
+
+       * - Treat
+         - Quantity
+         - Description
+       * - Albatross
+         - 2.99
+         - On a stick!
+       * - Crunchy Frog
+         - 1.49
+         - If we took the bones out, it wouldn't be
+           crunchy, now would it?
+       * - Gannet Ripple
+         - 1.99
+         - On a stick!
+
+The following options are recognized:
+
+
+``align`` : "left", "center", or "right"
+    The horizontal alignment of the table.
+    (New in Docutils 0.13)
+
+``header-rows`` : integer
+    The number of rows of list data to use in the table header.
+    Defaults to 0.
+
+``stub-columns`` : integer
+    The number of table columns to use as stubs (row titles, on the
+    left).  Defaults to 0.
+
+    .. _table width:
+
+``width`` : `length`_ or `percentage`_
+    Sets the width of the table to the specified length or percentage
+    of the line width.  If omitted, the renderer determines the width
+    of the table based on its contents or the column ``widths``.
+
+    .. _column widths:
+
+``widths`` : integer [integer...] or "auto"
+    A list of relative column widths.
+    The default is equal-width columns (100%/#columns).
+
+    "auto" delegates the determination of column widths to the backend
+    (LaTeX, the HTML browser, ...).
+
+and the common options class_ and name_.
+
+
+----------------
+ Document Parts
+----------------
+
+.. _contents:
+
+Table of Contents
+=================
+
+:Directive Type: "contents"
+:Doctree Elements: pending_, topic_
+:Directive Arguments: One, optional: title.
+:Directive Options: Possible (see below).
+:Directive Content: None.
+
+The "contents" directive generates a table of contents (TOC) in a
+topic_.  Topics, and therefore tables of contents, may occur anywhere
+a section or transition may occur.  Body elements and topics may not
+contain tables of contents.
+
+Here's the directive in its simplest form::
+
+    .. contents::
+
+Language-dependent boilerplate text will be used for the title.  The
+English default title text is "Contents".
+
+An explicit title may be specified::
+
+    .. contents:: Table of Contents
+
+The title may span lines, although it is not recommended::
+
+    .. contents:: Here's a very long Table of
+       Contents title
+
+Options may be specified for the directive, using a field list::
+
+    .. contents:: Table of Contents
+       :depth: 2
+
+If the default title is to be used, the options field list may begin
+on the same line as the directive marker::
+
+    .. contents:: :depth: 2
+
+The following options are recognized:
+
+``depth`` : integer
+    The number of section levels that are collected in the table of
+    contents.  The default is unlimited depth.
+
+``local`` : flag (empty)
+    Generate a local table of contents.  Entries will only include
+    subsections of the section in which the directive is given.  If no
+    explicit title is given, the table of contents will not be titled.
+
+``backlinks`` : "entry" or "top" or "none"
+    Generate links from section headers back to the table of contents
+    entries, the table of contents itself, or generate no back-links.
+
+``class`` : text
+    Set a `"classes"`_ attribute value on the topic element.  See the
+    class_ directive below.
+
+
+.. _sectnum:
+.. _section-numbering:
+
+Automatic Section Numbering
+===========================
+
+:Directive Type: "sectnum" or "section-numbering" (synonyms)
+:Doctree Elements: pending_, generated_
+:Directive Arguments: None.
+:Directive Options: Possible (see below).
+:Directive Content: None.
+:Configuration Setting: sectnum_xform_
+
+The "sectnum" (or "section-numbering") directive automatically numbers
+sections and subsections in a document (if not disabled by the
+``--no-section-numbering`` command line option or the `sectnum_xform`_
+configuration setting).
+
+Section numbers are of the "multiple enumeration" form, where each
+level has a number, separated by periods.  For example, the title of section
+1, subsection 2, subsubsection 3 would have "1.2.3" prefixed.
+
+The "sectnum" directive does its work in two passes: the initial parse
+and a transform.  During the initial parse, a "pending" element is
+generated which acts as a placeholder, storing any options internally.
+At a later stage in the processing, the "pending" element triggers a
+transform, which adds section numbers to titles.  Section numbers are
+enclosed in a "generated" element, and titles have their "auto"
+attribute set to "1".
+
+The following options are recognized:
+
+``depth`` : integer
+    The number of section levels that are numbered by this directive.
+    The default is unlimited depth.
+
+``prefix`` : string
+    An arbitrary string that is prefixed to the automatically
+    generated section numbers.  It may be something like "3.2.", which
+    will produce "3.2.1", "3.2.2", "3.2.2.1", and so on.  Note that
+    any separating punctuation (in the example, a period, ".") must be
+    explicitly provided.  The default is no prefix.
+
+``suffix`` : string
+    An arbitrary string that is appended to the automatically
+    generated section numbers.  The default is no suffix.
+
+``start`` : integer
+    The value that will be used for the first section number.
+    Combined with ``prefix``, this may be used to force the right
+    numbering for a document split over several source files.  The
+    default is 1.
+
+.. _sectnum_xform: ../../user/config.html#sectnum-xform
+
+
+.. _header:
+.. _footer:
+
+Document Header & Footer
+========================
+
+:Directive Types: "header" and "footer"
+:Doctree Elements: decoration_, header, footer
+:Directive Arguments: None.
+:Directive Options: None.
+:Directive Content: Interpreted as body elements.
+
+The "header" and "footer" directives create document decorations,
+useful for page navigation, notes, time/datestamp, etc.  For example::
+
+    .. header:: This space for rent.
+
+This will add a paragraph to the document header, which will appear at
+the top of the generated web page or at the top of every printed page.
+
+These directives may be used multiple times, cumulatively.  There is
+currently support for only one header and footer.
+
+.. note::
+
+   While it is possible to use the "header" and "footer" directives to
+   create navigational elements for web pages, you should be aware
+   that Docutils is meant to be used for *document* processing, and
+   that a navigation bar is not typically part of a document.
+
+   Thus, you may soon find Docutils' abilities to be insufficient for
+   these purposes.  At that time, you should consider using a
+   documentation generator like Sphinx_ rather than the "header" and
+   "footer" directives.
+
+   .. _Sphinx: http://sphinx-doc.org/
+
+In addition to the use of these directives to populate header and
+footer content, content may also be added automatically by the
+processing system.  For example, if certain runtime settings are
+enabled, the document footer is populated with processing information
+such as a datestamp, a link to `the Docutils website`_, etc.
+
+.. _the Docutils website: https://docutils.sourceforge.io
+
+
+------------
+ References
+------------
+
+.. _target-notes:
+
+Target Footnotes
+================
+
+:Directive Type: "target-notes"
+:Doctree Elements: pending_, footnote_, footnote_reference_
+:Directive Arguments: None.
+:Directive Options: class_, name_
+:Directive Options: Possible (see below).
+:Directive Content: None.
+
+The "target-notes" directive creates a footnote for each external
+target in the text, and corresponding footnote references after each
+reference.  For every explicit target (of the form, ``.. _target name:
+URL``) in the text, a footnote will be generated containing the
+visible URL as content.
+
+
+Footnotes
+=========
+
+**NOT IMPLEMENTED YET**
+
+:Directive Type: "footnotes"
+:Doctree Elements: pending_, topic_
+:Directive Arguments: None?
+:Directive Options: Possible?
+:Directive Content: None.
+
+@@@
+
+
+Citations
+=========
+
+**NOT IMPLEMENTED YET**
+
+:Directive Type: "citations"
+:Doctree Elements: pending_, topic_
+:Directive Arguments: None?
+:Directive Options: Possible?
+:Directive Content: None.
+
+@@@
+
+
+---------------
+ HTML-Specific
+---------------
+
+Imagemap
+========
+
+**NOT IMPLEMENTED YET**
+
+Non-standard element: imagemap.
+
+
+-----------------------------------------
+ Directives for Substitution Definitions
+-----------------------------------------
+
+The directives in this section may only be used in `substitution
+definitions`_.  They may not be used directly, in standalone context.
+The `image`_ directive may be used both in substitution definitions
+and in the standalone context.
+
+.. _substitution definitions:
+.. _substitution definition: restructuredtext.html#substitution-definitions
+
+.. _replace:
+
+Replacement Text
+================
+
+:Directive Type: "replace"
+:Doctree Element: Text & `inline elements`_
+:Directive Arguments: None.
+:Directive Options: None.
+:Directive Content: A single paragraph; may contain inline markup.
+
+The "replace" directive is used to indicate replacement text for a
+substitution reference.  It may be used within `substitution
+definitions`_ only.  For example, this directive can be used to expand
+abbreviations::
+
+    .. |reST| replace:: reStructuredText
+
+    Yes, |reST| is a long word, so I can't blame anyone for wanting to
+    abbreviate it.
+
+As reStructuredText doesn't support nested inline markup, the only way
+to create a reference with styled text is to use substitutions with
+the "replace" directive::
+
+    I recommend you try |Python|_.
+
+    .. |Python| replace:: Python, *the* best language around
+    .. _Python: https://www.python.org/
+
+
+.. _unicode:
+
+Unicode Character Codes
+=======================
+
+:Directive Type: "unicode"
+:Doctree Element: Text
+:Directive Arguments: One or more, required (Unicode character codes,
+                      optional text, and comments).
+:Directive Options: Possible (see below).
+:Directive Content: None.
+
+The "unicode" directive converts Unicode character codes (numerical
+values) to characters, and may be used in `substitution definitions`_
+only.
+
+The arguments, separated by spaces, can be:
+
+* **character codes** as
+
+  - decimal numbers or
+
+  - hexadecimal numbers, prefixed by ``0x``, ``x``, ``\x``, ``U+``, ``u``, or ``\u`` or as XML-style hexadecimal character entities, e.g. ``&#x1a2b;``
+
+* **text**, which is used as-is.
+
+Text following " .. " is a comment and is ignored.  The spaces between
+the arguments are ignored and thus do not appear in the output.
+Hexadecimal codes are case-insensitive.
+
+For example, the following text::
+
+    Copyright |copy| 2003, |BogusMegaCorp (TM)| |---|
+    all rights reserved.
+
+    .. |copy| unicode:: 0xA9 .. copyright sign
+    .. |BogusMegaCorp (TM)| unicode:: BogusMegaCorp U+2122
+       .. with trademark sign
+    .. |---| unicode:: U+02014 .. em dash
+       :trim:
+
+results in:
+
+    Copyright |copy| 2003, |BogusMegaCorp (TM)| |---|
+    all rights reserved.
+
+    .. |copy| unicode:: 0xA9 .. copyright sign
+    .. |BogusMegaCorp (TM)| unicode:: BogusMegaCorp U+2122
+       .. with trademark sign
+    .. |---| unicode:: U+02014 .. em dash
+       :trim:
+
+The following options are recognized:
+
+``ltrim`` : flag (empty)
+    Whitespace to the left of the substitution reference is removed.
+
+``rtrim`` : flag (empty)
+    Whitespace to the right of the substitution reference is removed.
+
+``trim`` : flag (empty)
+    Equivalent to ``ltrim`` plus ``rtrim``; whitespace on both sides
+    of the substitution reference is removed.
+
+
+Date
+====
+
+:Directive Type: "date"
+:Doctree Element: Text
+:Directive Arguments: One, optional (date format).
+:Directive Options: None.
+:Directive Content: None.
+
+The "date" directive generates the current local date and inserts it
+into the document as text.  This directive may be used in substitution
+definitions only.
+
+The optional directive content is interpreted as the desired date
+format, using the same codes as Python's `time.strftime()`__ function.  The
+default format is "%Y-%m-%d" (ISO 8601 date), but time fields can also
+be used.  Examples::
+
+    .. |date| date::
+    .. |time| date:: %H:%M
+
+    Today's date is |date|.
+
+    This document was generated on |date| at |time|.
+
+__ https://docs.python.org/3/library/time.html#time.strftime
+
+
+---------------
+ Miscellaneous
+---------------
+
+.. _include:
+
+Including an External Document Fragment
+=======================================
+
+:Directive Type: "include"
+:Doctree Elements: Depend on data being included
+                   (literal_block_ with ``code`` or ``literal`` option).
+:Directive Arguments: One, required (path to the file to include).
+:Directive Options: Possible (see below).
+:Directive Content: None.
+:Configuration Setting: file_insertion_enabled_
+
+.. WARNING::
+
+   The "include" directive represents a potential security hole.  It
+   can be disabled with the "file_insertion_enabled_" runtime setting.
+
+   .. _file_insertion_enabled: ../../user/config.html#file-insertion-enabled
+
+The "include" directive reads a text file. The directive argument is
+the path to the file to be included, relative to the document containing
+the directive. Unless the options ``literal``, ``code``, or ``parser``
+are given, the file is parsed in the current document's context at the
+point of the directive. For example::
+
+    This first example will be parsed at the document level, and can
+    thus contain any construct, including section headers.
+
+    .. include:: inclusion.txt
+
+    Back in the main document.
+
+        This second example will be parsed in a block quote context.
+        Therefore it may only contain body elements.  It may not
+        contain section headers.
+
+        .. include:: inclusion.txt
+
+If an included document fragment contains section structure, the title
+adornments must match those of the master document.
+
+Standard data files intended for inclusion in reStructuredText
+documents are distributed with the Docutils source code, located in
+the "docutils" package in the ``docutils/parsers/rst/include``
+directory.  To access these files, use the special syntax for standard
+"include" data files, angle brackets around the file name::
+
+    .. include:: <isonum.txt>
+
+The current set of standard "include" data files consists of sets of
+substitution definitions.  See `reStructuredText Standard Definition
+Files`__ for details.
+
+__ definitions.html
+
+The following options are recognized:
+
+``start-line`` : integer
+    Only the content starting from this line will be included.
+    (As usual in Python, the first line has index 0 and negative values
+    count from the end.)
+
+``end-line`` : integer
+    Only the content up to (but excluding) this line will be included.
+
+``start-after`` : text to find in the external data file
+    Only the content after the first occurrence of the specified text
+    will be included.
+
+``end-before`` : text to find in the external data file
+    Only the content before the first occurrence of the specified text
+    (but after any ``after`` text) will be included.
+
+``parser`` :  parser name
+    Parse the included content with the specified parser.
+    (New in Docutils 0.17)
+
+``literal`` : flag (empty)
+    The entire included text is inserted into the document as a single
+    literal block.
+
+``code`` : [string] (formal language)
+    The argument and the included content are passed to
+    the code_ directive (useful for program listings).
+
+``number-lines`` : [integer] (start line number)
+    Precede every code line with a line number.
+    The optional argument is the number of the first line (default 1).
+    Works only with ``code`` or ``literal``.
+
+``encoding`` : string
+    The text encoding of the external data file.  Defaults to the
+    document's input_encoding_.
+
+    .. _input_encoding: ../../user/config.html#input-encoding
+
+``tab-width`` :  integer
+    Number of spaces for hard tab expansion.
+    A negative value prevents expansion of hard tabs. Defaults to the
+    tab_width_ configuration setting.
+
+    .. _tab_width: ../../user/config.html#tab-width
+
+With ``code`` or ``literal`` the common options class_ and
+name_ are recognized as well.
+
+Combining ``start/end-line`` and ``start-after/end-before`` is possible. The
+text markers will be searched in the specified lines (further limiting the
+included content).
+
+.. _raw-directive:
+
+Raw Data Pass-Through
+=====================
+
+:Directive Type: "raw"
+:Doctree Element: raw_
+:Directive Arguments: One or more, required (output format types).
+:Directive Options: Possible (see below).
+:Directive Content: Stored verbatim, uninterpreted.  None (empty) if a
+                    "file" or "url" option given.
+:Configuration Setting: raw_enabled_
+
+.. WARNING::
+
+   The "raw" directive represents a potential security hole.  It can
+   be disabled with the "raw_enabled_" or "file_insertion_enabled_"
+   runtime settings.
+
+   .. _raw_enabled: ../../user/config.html#raw-enabled
+
+.. Caution::
+
+   The "raw" directive is a stop-gap measure allowing the author to
+   bypass reStructuredText's markup.  It is a "power-user" feature
+   that should not be overused or abused.  The use of "raw" ties
+   documents to specific output formats and makes them less portable.
+
+   If you often need to use the "raw" directive or a "raw"-derived
+   interpreted text role, that is a sign either of overuse/abuse or
+   that functionality may be missing from reStructuredText.  Please
+   describe your situation in a message to the Docutils-users_ mailing
+   list.
+
+.. _Docutils-users: ../../user/mailing-lists.html#docutils-users
+
+The "raw" directive indicates non-reStructuredText data that is to be
+passed untouched to the Writer.  The names of the output formats are
+given in the directive arguments.  The interpretation of the raw data
+is up to the Writer.  A Writer may ignore any raw output not matching
+its format.
+
+For example, the following input would be passed untouched by an HTML
+Writer::
+
+    .. raw:: html
+
+       <hr width=50 size=10>
+
+A LaTeX Writer could insert the following raw content into its
+output stream::
+
+    .. raw:: latex
+
+       \setlength{\parindent}{0pt}
+
+Raw data can also be read from an external file, specified in a
+directive option.  In this case, the content block must be empty.  For
+example::
+
+    .. raw:: html
+       :file: inclusion.html
+
+Inline equivalents of the "raw" directive can be defined via
+`custom interpreted text roles`_ derived from the `"raw" role`_.
+
+The following options are recognized:
+
+``file`` : string (newlines removed)
+    The local filesystem path of a raw data file to be included.
+
+``url`` : string (whitespace removed)
+    An Internet URL reference to a raw data file to be included.
+
+``encoding`` : string
+    The text encoding of the external raw data (file or URL).
+    Defaults to the document's encoding (if specified).
+
+and the common option class_.
+
+
+.. _"raw" role: roles.html#raw
+
+
+.. _classes:
+
+Class
+=====
+
+:Directive Type: "class"
+:Doctree Element: pending_
+:Directive Arguments: One or more, required (class names / attribute
+                      values).
+:Directive Options: None.
+:Directive Content: Optional.  If present, it is interpreted as body
+                    elements.
+
+The "class" directive sets the `"classes"`_ attribute value on its content
+or on the first immediately following [#]_ non-comment element [#]_.
+The directive argument consists of one or more space-separated class
+names. The names are transformed to conform to the regular expression
+``[a-z](-?[a-z0-9]+)*`` (see `Identifier Normalization`_ below).
+
+Examples::
+
+    .. class:: special
+
+    This is a "special" paragraph.
+
+    .. class:: exceptional remarkable
+
+    An Exceptional Section
+    ======================
+
+    This is an ordinary paragraph.
+
+    .. class:: multiple
+
+       First paragraph.
+
+       Second paragraph.
+
+The text above is parsed and transformed into this doctree fragment::
+
+.. code-block:: xml
+
+    <paragraph classes="special">
+        This is a "special" paragraph.
+    <section classes="exceptional remarkable">
+        <title>
+            An Exceptional Section
+        <paragraph>
+            This is an ordinary paragraph.
+        <paragraph classes="multiple">
+            First paragraph.
+        <paragraph classes="multiple">
+            Second paragraph.
+
+
+.. [#] This is also true, if the class directive is "nested" at the end of
+   an indented text block, for example::
+
+       .. note:: the class values set in this directive-block do not apply to
+          the note but the next paragraph.
+
+          .. class:: special
+
+       This is a paragraph with class value "special".
+
+   This allows the "classification" of individual list items (except the
+   first, as a preceding class directive applies to the list as a whole)::
+
+       * bullet list
+
+         .. class:: classy item
+
+       * second item, with class argument
+
+.. [#] To set a "classes" attribute value on a block quote, the
+   "class" directive must be followed by an empty comment::
+
+       .. class:: highlights
+       ..
+
+           Block quote text.
+
+   Without the empty comment, the indented text would be interpreted as the
+   "class" directive's content, and the classes would be applied to each
+   element (paragraph, in this case) individually, instead of to the block
+   quote as a whole.
+
+
+Identifier Normalization
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Docutils `class names`_ and `identifier keys`_ are normalized to conform
+to the regular expression "``[a-z](-?[a-z0-9]+)*``" by converting
+
+* alphabetic characters to lowercase,
+* accented characters to the base character,
+* non-alphanumeric characters to hyphens,
+* consecutive hyphens into one hyphen
+
+and stripping
+
+* leading hyphens and number characters, and
+* trailing hyphens.
+
+For example ``"Rot.Gelb&GrÃ¼n:+2008"`` becomes ``"rot-gelb-grun-2008"`` and
+``"1000_Steps!"`` becomes ``"steps"``.
+
+.. topic:: Rationale:
+
+    Identifier keys must be valid in all supported output formats.
+
+    For HTMLÂ 4.1 + CSS1 compatibility, identifiers should have no
+    underscores, colons, or periods.  Hyphens may be used.
+
+    - The `HTML 4.01 spec`_ defines identifiers based on SGML tokens:
+
+          ID and NAME tokens must begin with a letter ([A-Za-z]) and
+          may be followed by any number of letters, digits ([0-9]),
+          hyphens ("-"), underscores ("_"), colons (":"), and periods
+          (".").
+
+          -- https://www.w3.org/TR/html401/types.html#type-name
+
+    - The `CSS1 spec`_ defines identifiers based on the "name" token
+      ("flex" tokenizer notation below; "latin1" and "escape" 8-bit
+      characters have been replaced with XML entities)::
+
+          unicode     \\[0-9a-f]{1,4}
+          latin1      [&iexcl;-&yuml;]
+          escape      {unicode}|\\[ -~&iexcl;-&yuml;]
+          nmchar      [-A-Za-z0-9]|{latin1}|{escape}
+          name        {nmchar}+
+
+    The CSS1 rule requires underscores ("_"), colons (":"), and
+    periods (".") to be escaped [#]_,
+    therefore `"classes"`_ and `"ids"`_ attributes should not
+    contain these characters.  Combined with HTML4.1 requirements (the
+    first character must be a letter; no "unicode", "latin1", or
+    "escape" characters), this results in the regular expression
+    ``[A-Za-z][-A-Za-z0-9]*``. Docutils adds a normalization by
+    downcasing and merge of consecutive hyphens.
+
+    .. [#] CSS identifiers may use underscores ("_") directly in
+       `CSSÂ LevelÂ 1`__, `CSS2.1`__, CSS2.2__, and CSS3__.
+
+       __ https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
+       __ https://www.w3.org/TR/CSS/#css-level-1
+       __ https://www.w3.org/TR/CSS22/syndata.html
+       __ https://www.w3.org/TR/css-syntax-3/#typedef-ident-token
+
+    .. _HTML 4.01 spec: https://www.w3.org/TR/html401/
+    .. _CSS1 spec: https://www.w3.org/TR/REC-CSS1
+
+.. _role:
+
+Custom Interpreted Text Roles
+=============================
+
+:Directive Type: "role"
+:Doctree Element: None; affects subsequent parsing.
+:Directive Arguments: Two; one required (new `role name`_), one optional
+                      (base role name, in parentheses).
+:Directive Options: Possible (depends on base role).
+:Directive Content: depends on base role.
+
+The "role" directive dynamically creates a custom `interpreted text
+role`_ and registers it with the parser.  This means that after
+declaring a role like this::
+
+    .. role:: custom
+
+the document may use the new "custom" role::
+
+    An example of using :custom:`interpreted text`
+
+This will be parsed into the following document tree fragment::
+
+.. code-block:: xml
+
+    <paragraph>
+        An example of using
+        <inline classes="custom">
+            interpreted text
+
+The role must be declared in a document before it can be used.
+
+.. _role name:
+
+Role names are case insensitive and must conform to the rules of
+simple `reference names`_ (but do not share a namespace with
+hyperlinks, footnotes, and citations).
+
+The new role may be based on an existing role, specified as a second
+argument in parentheses (whitespace optional)::
+
+    .. role:: custom(emphasis)
+
+    :custom:`text`
+
+The parsed result is as follows::
+
+.. code-block:: xml
+
+    <paragraph>
+        <emphasis classes="custom">
+            text
+
+A special case is the `"raw" role`_: derived roles enable
+inline `raw data pass-through`_, e.g.::
+
+   .. role:: raw-role(raw)
+      :format: html latex
+
+   :raw-role:`raw text`
+
+If no base role is explicitly specified, a generic custom role is
+automatically used.  Subsequent interpreted text will produce an
+"inline" element with a `"classes"`_ attribute, as in the first example
+above.
+
+With most roles, the ":class:" option can be used to set a "classes"
+attribute that is different from the role name.  For example::
+
+    .. role:: custom
+       :class: special
+
+    :custom:`interpreted text`
+
+This is the parsed result::
+
+.. code-block:: xml
+
+    <paragraph>
+        <inline classes="special">
+            interpreted text
+
+.. _role class:
+
+The following option is recognized by the "role" directive for most
+base roles:
+
+``class`` : text
+    Set the `"classes"`_ attribute value on the element produced
+    (``inline``, or element associated with a base class) when the
+    custom interpreted text role is used.  If no directive options are
+    specified, a "class" option with the directive argument (role
+    name) as the value is implied.  See the class_ directive above.
+
+Specific base roles may support other options and/or directive
+content.  See the `reStructuredText Interpreted Text Roles`_ document
+for details.
+
+.. _reStructuredText Interpreted Text Roles: roles.html
+
+
+.. _default-role:
+
+Setting the Default Interpreted Text Role
+=========================================
+
+:Directive Type: "default-role"
+:Doctree Element: None; affects subsequent parsing.
+:Directive Arguments: One, optional (new default role name).
+:Directive Options: None.
+:Directive Content: None.
+
+The "default-role" directive sets the default interpreted text role,
+the role that is used for interpreted text without an explicit role.
+For example, after setting the default role like this::
+
+    .. default-role:: subscript
+
+any subsequent use of implicit-role interpreted text in the document
+will use the "subscript" role::
+
+    An example of a `default` role.
+
+This will be parsed into the following document tree fragment
+
+.. code-block:: xml
+
+    <paragraph>
+        An example of a
+        <subscript>
+            default
+         role.
+
+Custom roles may be used (see the "role_" directive above), but it
+must have been declared in a document before it can be set as the
+default role.  See the `reStructuredText Interpreted Text Roles`_
+document for details of built-in roles.
+
+The directive may be used without an argument to restore the initial
+default interpreted text role, which is application-dependent.  The
+initial default interpreted text role of the standard reStructuredText
+parser is "title-reference".
+
+
+Metadata
+========
+
+:Directive Type: "meta"
+:Doctree Element: meta_
+:Directive Arguments: None.
+:Directive Options: None.
+:Directive Content: Must contain a flat field list.
+
+The "meta" directive is used to specify metadata\ [#]_ to be stored
+in, e.g., `HTML meta elements`_ or as `ODT file properties`_. The
+LaTeX writer passes it to the ``pdfinfo`` option of the hyperref_
+package. If an output format does not support "invisible" metadata,
+content is silently dropped by the writer.
+
+.. note:: Data from some `bibliographic fields`_ is automatically
+   extracted and stored as metadata, too. However, Bibliographic
+   Fields are also displayed in the document's screen rendering or
+   printout.
+
+   For an "invisible" *document title*, see the `metadata document
+   title`_ directive below.
+
+Within the directive block, a flat field list provides the syntax for
+metadata.  The field name becomes the contents of the "name" attribute
+of the META tag, and the field body (interpreted as a single string
+without inline markup) becomes the contents of the "content"
+attribute.  For example::
+
+    .. meta::
+       :description: The reStructuredText plaintext markup language
+       :keywords: plaintext, markup language
+
+This would be converted to the following HTML
+
+.. code-block:: html
+
+    <meta name="description"
+        content="The reStructuredText plaintext markup language">
+    <meta name="keywords" content="plaintext, markup language">
+
+Support for other META attributes ("http-equiv", "scheme", "lang",
+"dir") are provided through field arguments, which must be of the form
+"attr=value"::
+
+    .. meta::
+       :description lang=en: An amusing story
+       :description lang=fr: Une histoire amusante
+
+And their HTML equivalents
+
+.. code-block:: html
+
+    <meta name="description" lang="en" content="An amusing story">
+    <meta name="description" lang="fr" content="Une histoire amusante">
+
+Some META tags use an "http-equiv" attribute instead of the "name"
+attribute.  To specify "http-equiv" META tags, simply omit the name::
+
+    .. meta::
+       :http-equiv=Content-Type: text/html; charset=ISO-8859-1
+
+HTML equivalent
+
+.. code-block:: html
+
+    <meta http-equiv="Content-Type"
+         content="text/html; charset=ISO-8859-1">
+
+.. [#] "Metadata" is data about data, in this case data about the
+   document. Metadata is, e.g., used to describe and classify web
+   pages in the World Wide Web, in a form that is easy for search
+   engines to extract and collate.
+
+.. _HTML meta elements:
+   https://html.spec.whatwg.org/multipage/semantics.html#the-meta-element
+.. _ODT file properties:
+   https://en.wikipedia.org/wiki/OpenDocument_technical_specification#Metadata
+.. _hyperref: https://ctan.org/pkg/hyperref
+.. _bibliographic fields: restructuredtext.html#bibliographic-fields
+
+
+Metadata Document Title
+=======================
+
+:Directive Type: "title"
+:Doctree Element: Sets the document's `title attribute`_.
+:Directive Arguments: One, required (the title text).
+:Directive Options: None.
+:Directive Content: None.
+
+The "title" directive specifies the document title as metadata, which
+does not become part of the document body. It overrides the
+document-supplied `document title`_ and the `"title" configuration
+setting`_. For example, in HTML output the metadata document title
+appears in the title bar of the browser window.
+
+.. _document title: restructuredtext.html#document-title
+.. _"title" configuration setting: ../../user/config.html#title
+
+Restructuredtext-Test-Directive
+===============================
+
+:Directive Type: "restructuredtext-test-directive"
+:Doctree Element: system_warning
+:Directive Arguments: None.
+:Directive Options: None.
+:Directive Content: Interpreted as a literal block.
+
+This directive is provided for test purposes only.  (Nobody is
+expected to type in a name *that* long!)  It is converted into a
+level-1 (info) system message showing the directive data, possibly
+followed by a literal block containing the rest of the directive
+block.
+
+--------------
+Common Options
+--------------
+
+Most of the directives that generate doctree elements support the following
+options:
+
+.. _class-option:
+.. _class:
+
+``class`` : text (space separated list of `class names`_)
+    Set a `"classes"`_ attribute value on the doctree element generated by
+    the directive. See also the class_ directive.
+
+    .. _name:
+
+``name`` : text
+    Add `text` to the `"names"`_ attribute of the doctree element generated
+    by the directive. This allows `hyperlink references`_ to the element
+    using `text` as `reference name`_.
+
+    Specifying the `name` option of a directive, e.g., ::
+
+      .. image:: bild.png
+         :name: my picture
+
+    is a concise syntax alternative to preceding it with a `hyperlink
+    target`_ ::
+
+      .. _my picture:
+
+      .. image:: bild.png
+
+
+.. _reference name:
+.. _reference names: restructuredtext.html#reference-names
+.. _hyperlink target: restructuredtext.html#hyperlink-targets
+.. _hyperlink references: restructuredtext.html#hyperlink-references
+.. _class names: ../doctree.html#classnames-type
+.. _"classes": ../doctree.html#classes
+.. _identifier keys: ../doctree.html#ids-type
+.. _"ids": ../doctree.html#ids
+.. _"names": ../doctree.html#names
+.. _admonition: ../doctree.html#admonition
+.. _block_quote: ../doctree.html#block-quote
+.. _caption: ../doctree.html#caption
+.. _compound: ../doctree.html#compound
+.. _container element: ../doctree.html#container
+.. _decoration: ../doctree.html#decoration
+.. _figure: ../doctree.html#figure
+.. _footnote: ../doctree.html#footnote
+.. _footnote_reference: ../doctree.html#footnote-reference
+.. _generated: ../doctree.html#generated
+.. _image: ../doctree.html#image
+.. _inline elements: ../doctree.html#inline-elements
+.. _interpreted text role: roles.html
+.. _literal_block: ../doctree.html#literal-block
+.. _legend: ../doctree.html#legend
+.. _length: restructuredtext.html#length-units
+.. _line_block: ../doctree.html#line-block
+.. _math_block: ../doctree.html#math-block
+.. _meta: ../doctree.html#meta
+.. _pending: ../doctree.html#pending
+.. _percentage: restructuredtext.html#percentage-units
+.. _raw: ../doctree.html#raw
+.. _rubric: ../doctree.html#rubric
+.. _sidebar: ../doctree.html#sidebar
+.. _table: ../doctree.html#table
+.. _title: ../doctree.html#title
+.. _title attribute: ../doctree.html#title-attribute
+.. _topic: ../doctree.html#topic
+
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   End:

--- a/tests/test_vectors/directives_expected.html
+++ b/tests/test_vectors/directives_expected.html
@@ -1705,7 +1705,6 @@ argument (role name) as the value is implied.  See the class directive above.
 references to the element using text as reference name.  Specifying the name option of a directive, e.g.,  .. image:: 
 bild.png    :name: my picture  is a concise syntax alternative to preceding it with a hyperlink target  .. _my picture: 
 .. image:: bild.png
-
 <span class="r23">╭───────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 982); ─────────────────────────────────╮</span>
 <span class="r23">│</span> <span class="r1">&lt;</span><span class="r24">rst-document</span><span class="r1">&gt;</span>:<span class="r23">982</span>: <span class="r1">(</span>INFO/<span class="r23">1</span><span class="r1">)</span> Duplicate implicit target name: <span class="r25">&quot;contents&quot;</span>.                                             <span class="r23">│</span>
 <span class="r23">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>

--- a/tests/test_vectors/directives_expected.html
+++ b/tests/test_vectors/directives_expected.html
@@ -1,0 +1,1741 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+.r1 {font-weight: bold}
+.r2 {color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #282a36}
+.r3 {color: #949494; text-decoration-color: #949494}
+.r4 {color: #ff4689; text-decoration-color: #ff4689; background-color: #272822}
+.r5 {background-color: #272822}
+.r6 {color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822}
+.r7 {color: #e6db74; text-decoration-color: #e6db74; background-color: #272822}
+.r8 {color: #bd93f9; text-decoration-color: #bd93f9; background-color: #282a36; text-decoration: underline}
+.r9 {color: #ed007e; text-decoration-color: #ed007e; background-color: #1e0010}
+.r10 {color: #f1fa8c; text-decoration-color: #f1fa8c; font-weight: bold}
+.r11 {color: #a6e22e; text-decoration-color: #a6e22e; background-color: #272822}
+.r12 {color: #ae81ff; text-decoration-color: #ae81ff; background-color: #272822}
+.r13 {color: #8be9fd; text-decoration-color: #8be9fd}
+.r14 {color: #66d9ef; text-decoration-color: #66d9ef; background-color: #272822}
+.r15 {color: #ffffff; text-decoration-color: #ffffff; font-weight: bold}
+.r16 {color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #282a36; font-style: italic}
+.r17 {color: #c6c6c6; text-decoration-color: #c6c6c6; background-color: #121212}
+.r18 {color: #ff79c6; text-decoration-color: #ff79c6}
+.r19 {color: #ffffff; text-decoration-color: #ffffff}
+.r20 {color: #e4e4e4; text-decoration-color: #e4e4e4}
+.r21 {color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #282a36; font-weight: bold}
+.r22 {color: #ff5555; text-decoration-color: #ff5555}
+.r23 {color: #8be9fd; text-decoration-color: #8be9fd; font-weight: bold}
+.r24 {color: #ff79c6; text-decoration-color: #ff79c6; font-weight: bold}
+.r25 {color: #50fa7b; text-decoration-color: #50fa7b}
+.r26 {color: #bcbcbc; text-decoration-color: #bcbcbc}
+body {
+    color: #f8f8f2;
+    background-color: #282a36;
+}
+</style>
+</head>
+<body>
+    <pre style="font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace"><code style="font-family:inherit"><span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                             reStructuredText Directives                                              ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name </span>┃<span class="r1"> Field Value                                           </span>┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Author    </span> │ David Goodger                                         │
+├────────────┼───────────────────────────────────────────────────────┤
+│ <span class="r1">Contact   </span> │ docutils-develop@lists.sourceforge.net                │
+├────────────┼───────────────────────────────────────────────────────┤
+│ <span class="r1">Revision  </span> │ $Revision: 8959 $                                     │
+├────────────┼───────────────────────────────────────────────────────┤
+│ <span class="r1">Date      </span> │ $Date: 2022-01-21 14:45:42 +0100 (Fr, 21. Jan 2022) $ │
+├────────────┼───────────────────────────────────────────────────────┤
+│ <span class="r1">Copyright </span> │ This document has been placed in the public domain.   │
+└────────────┴───────────────────────────────────────────────────────┘
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                       Contents                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r2">This document describes the directives implemented in the reference reStructuredText parser.</span>
+
+<span class="r2">Directives have the following syntax:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">+-------+-------------------------------+</span><span class="r5">                                                                           </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">|</span><span class="r6"> </span><span class="r7">&quot;.. &quot;</span><span class="r6"> </span><span class="r4">|</span><span class="r6"> directive type </span><span class="r7">&quot;::&quot;</span><span class="r6"> directive </span><span class="r4">|</span><span class="r5">                                                                           </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">+-------+</span><span class="r6"> block                         </span><span class="r4">|</span><span class="r5">                                                                           </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">        </span><span class="r4">|</span><span class="r6">                               </span><span class="r4">|</span><span class="r5">                                                                           </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">        </span><span class="r4">+-------------------------------+</span><span class="r5">                                                                           </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">Directives begin with an explicit markup start (two periods and a space), followed by the directive type and two colons </span>
+<span class="r2">(collectively, the &quot;directive marker&quot;).  The directive block begins immediately after the directive marker, and includes</span>
+<span class="r2">all subsequent indented lines.  The directive block is divided into arguments, options (a field list), and content (in </span>
+<span class="r2">that order), any of which may appear.  See the </span><a class="r8" href="restructuredtext.html#directives">Directives</a><span class="r2"> section in the </span><a class="r8" href="restructuredtext.html">reStructuredText Markup Specification</a><span class="r2"> for </span>
+<span class="r2">syntax details.</span>
+
+<span class="r2">Descriptions below list &quot;doctree elements&quot; (document tree element names; XML DTD generic identifiers) corresponding to </span>
+<span class="r2">individual directives.  For details on the hierarchy of elements, please see </span><a class="r8" href="../doctree.html">The Docutils Document Tree</a><span class="r2"> and the </span><a class="r8" href="../docutils.dtd">Docutils</a>
+<a class="r8" href="../docutils.dtd">Generic DTD</a><span class="r2"> XML document type definition.  For directive implementation details, see </span><a class="r8" href="../../howto/rst-directives.html">Creating reStructuredText </a>
+<a class="r8" href="../../howto/rst-directives.html">Directives</a><span class="r2">.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     Admonitions                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                 Specific Admonitions                                                 ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                                         </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Types    </span> │ &quot;attention&quot;, &quot;caution&quot;, &quot;danger&quot;, &quot;error&quot;, &quot;hint&quot;,  │
+│                     │ &quot;important&quot;, &quot;note&quot;, &quot;tip&quot;, &quot;warning&quot;, &quot;admonition&quot; │
+├─────────────────────┼─────────────────────────────────────────────────────┤
+│ <span class="r1">Doctree Elements   </span> │ attention, caution, danger, error, hint, important, │
+│                     │ note, tip, warning, admonition, title               │
+├─────────────────────┼─────────────────────────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ None.                                               │
+├─────────────────────┼─────────────────────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ class, name                                         │
+├─────────────────────┼─────────────────────────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ Interpreted as body elements.                       │
+└─────────────────────┴─────────────────────────────────────────────────────┘
+<span class="r2">Admonitions are specially marked &quot;topics&quot; that can appear anywhere an ordinary body element can.  They contain arbitrary</span>
+<span class="r2">body elements. Typically, an admonition is rendered as an offset block in a document, sometimes outlined or shaded, with</span>
+<span class="r2">a title matching the admonition type.  For example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> DANGER::</span><span class="r5">                                                                                                         </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   Beware killer rabbits</span><span class="r9">!</span><span class="r5">                                                                                           </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">This directive might be rendered something like this:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">+------------------------+</span><span class="r5">                                                                                          </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">|</span><span class="r6">        </span><span class="r9">!</span><span class="r6">DANGER</span><span class="r9">!</span><span class="r6">        </span><span class="r4">|</span><span class="r5">                                                                                          </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">|</span><span class="r6">                        </span><span class="r4">|</span><span class="r5">                                                                                          </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">|</span><span class="r6"> Beware killer rabbits</span><span class="r9">!</span><span class="r6"> </span><span class="r4">|</span><span class="r5">                                                                                          </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">+------------------------+</span><span class="r5">                                                                                          </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">The following admonition directives have been implemented:</span>
+
+<span class="r10"> • </span>attention
+<span class="r10"> • </span>caution
+<span class="r10"> • </span>danger
+<span class="r10"> • </span>error
+<span class="r10"> • </span>hint
+<span class="r10"> • </span>important
+<span class="r10"> • </span>note
+<span class="r10"> • </span>tip
+<span class="r10"> • </span>warning
+<span class="r2">Any text immediately following the directive indicator (on the same line and/or indented on following lines) is </span>
+<span class="r2">interpreted as a directive block and is parsed for normal body elements.  For example, the following &quot;note&quot; admonition </span>
+<span class="r2">directive contains one paragraph and a bullet list consisting of two list items:</span>
+
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> note:: This </span><span class="r4">is</span><span class="r6"> a note admonition</span><span class="r4">.</span><span class="r5">                                                                                </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   This </span><span class="r4">is</span><span class="r6"> the second line of the first paragraph</span><span class="r4">.</span><span class="r5">                                                                  </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r4">-</span><span class="r6"> The note contains all indented body elements</span><span class="r5">                                                                   </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">     following</span><span class="r4">.</span><span class="r5">                                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r4">-</span><span class="r6"> It includes this bullet list</span><span class="r4">.</span><span class="r5">                                                                                  </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                  Generic Admonition                                                  ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                      </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;admonition&quot;                     │
+├─────────────────────┼──────────────────────────────────┤
+│ <span class="r1">Doctree Elements   </span> │ admonition, title                │
+├─────────────────────┼──────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ One, required (admonition title) │
+├─────────────────────┼──────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ class, name                      │
+├─────────────────────┼──────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ Interpreted as body elements.    │
+└─────────────────────┴──────────────────────────────────┘
+<span class="r2">This is a generic, titled admonition.  The title may be anything the author desires.</span>
+
+<span class="r2">The author-supplied title is also used as a </span><span class="r8">&quot;classes&quot;</span><span class="r2"> attribute value after being converted into a valid identifier form</span>
+<span class="r2">(down-cased; non-alphanumeric characters converted to single hyphens; &quot;admonition-&quot; prefixed).  For example, this </span>
+<span class="r2">admonition:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> admonition:: And, by the way</span><span class="r4">...</span><span class="r5">                                                                                  </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   You can make up your own admonition too</span><span class="r4">.</span><span class="r5">                                                                         </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">becomes the following document tree (pseudo-XML)</span>
+<span class="r3">┌──────────────────────────────────────────────────────── xml ─────────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">&lt;document</span><span class="r6"> </span><span class="r11">source=</span><span class="r7">&quot;test data&quot;</span><span class="r4">&gt;</span><span class="r5">                                                                                       </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">    </span><span class="r4">&lt;admonition</span><span class="r6"> </span><span class="r11">classes=</span><span class="r7">&quot;admonition-and-by-the-way&quot;</span><span class="r4">&gt;</span><span class="r5">                                                                </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">        </span><span class="r4">&lt;title&gt;</span><span class="r5">                                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">            And, by the way...</span><span class="r5">                                                                                      </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">        </span><span class="r4">&lt;paragraph&gt;</span><span class="r5">                                                                                                 </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">            You can make up your own admonition too.</span><span class="r5">                                                                </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">The </span><span class="r8">class</span><span class="r2"> option overrides the computed </span><span class="r8">&quot;classes&quot;</span><span class="r2"> attribute value.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                        Images                                                        ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r2">There are two image directives: &quot;image&quot; and &quot;figure&quot;.</span>
+
+<span class="r2">It is up to the author to ensure compatibility of the image data format with the output format or user agent (</span><span class="r8">LaTeX</span><span class="r2"> </span>
+<span class="r2">engine, </span><span class="r8">HTML5 browser</span><span class="r2">, ODT, ...). The following, non exhaustive table provides an overview</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                        Image                                                         ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;image&quot;                    │
+├─────────────────────┼────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ image                      │
+├─────────────────────┼────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ One, required (image URI). │
+├─────────────────────┼────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ Possible (see below).      │
+├─────────────────────┼────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ None.                      │
+└─────────────────────┴────────────────────────────┘
+<span class="r2">An &quot;image&quot; is a simple picture:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> image:: picture</span><span class="r4">.</span><span class="r6">png</span><span class="r5">                                                                                              </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">Inline images can be defined with an &quot;image&quot; directive in a </span><a class="r8" href="restructuredtext.html#substitution-definitions">substitution definition</a>
+
+<span class="r2">The URI for the image source file is specified in the directive argument.  As with hyperlink targets, the image URI may </span>
+<span class="r2">begin on the same line as the explicit markup start and target name, or it may begin in an indented text block </span>
+<span class="r2">immediately following, with no intervening blank lines.  If there are multiple lines in the link block, they are </span>
+<span class="r2">stripped of leading and trailing whitespace and joined together.</span>
+
+<span class="r2">Optionally, the image link block may contain a flat field list, the .  For example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> image:: picture</span><span class="r4">.</span><span class="r6">jpeg</span><span class="r5">                                                                                             </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :height: </span><span class="r12">100</span><span class="r6">px</span><span class="r5">                                                                                                   </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :width: </span><span class="r12">200</span><span class="r6"> px</span><span class="r5">                                                                                                   </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :scale: </span><span class="r12">50</span><span class="r6"> </span><span class="r4">%</span><span class="r5">                                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :alt: alternate text</span><span class="r5">                                                                                             </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :align: right</span><span class="r5">                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">The following options are recognized:</span>
+
+    alt : <span class="r13">text</span>
+      Alternate text: a short description of the image, displayed by applications that cannot display images, or spoken 
+by applications for visually impaired users.
+
+    height : <span class="r13">length</span>
+      The desired height of the image. Used to reserve space or scale the image vertically.  When the &quot;scale&quot; option is 
+also specified, they are combined.  For example, a height of 200px and a scale of 50 is equivalent to a height of 100px 
+with no scale.
+
+    width : <span class="r13">length or percentage of the current line width</span>
+      The width of the image. Used to reserve space or scale the image horizontally.  As with &quot;height&quot; above, when the 
+&quot;scale&quot; option is also specified, they are combined.
+
+    scale : <span class="r13">integer percentage (the &quot;%&quot; symbol is optional)</span>
+      The uniform scaling factor of the image.  The default is &quot;100Â %&quot;, i.e. no scaling.  If no &quot;height&quot; or &quot;width&quot; 
+options are specified, the Python Imaging Library (PIL/Pillow) may be used to determine them, if it is installed and the
+image file is available.
+
+    align : <span class="r13">&quot;top&quot;, &quot;middle&quot;, &quot;bottom&quot;, &quot;left&quot;, &quot;center&quot;, or &quot;right&quot;</span>
+      The alignment of the image, equivalent to the HTML &lt;img&gt; tag&#x27;s deprecated &quot;align&quot; attribute or the corresponding 
+&quot;vertical-align&quot; and &quot;text-align&quot; CSS properties. The values &quot;top&quot;, &quot;middle&quot;, and &quot;bottom&quot; control an image&#x27;s vertical 
+alignment (relative to the text baseline); they are only useful for inline images (substitutions). The values &quot;left&quot;, 
+&quot;center&quot;, and &quot;right&quot; control an image&#x27;s horizontal alignment, allowing the image to float and have the text flow around
+it.  The specific behavior depends upon the browser or rendering software used.
+
+    target : <span class="r13">text (URI or reference name)</span>
+      Makes the image into a hyperlink reference (&quot;clickable&quot;).  The option argument may be a URI (relative or 
+absolute), or a reference name with underscore suffix (e.g. `a name`_).
+<span class="r2">and the common options </span><span class="r8">class</span><span class="r2"> and </span><span class="r8">name</span><span class="r2">.</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                        Figure                                                        ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                                       </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;figure&quot;                                          │
+├─────────────────────┼───────────────────────────────────────────────────┤
+│ <span class="r1">Doctree Elements   </span> │ figure, image, caption, legend                    │
+├─────────────────────┼───────────────────────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ One, required (image URI).                        │
+├─────────────────────┼───────────────────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ Possible (see below).                             │
+├─────────────────────┼───────────────────────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ Interpreted as the figure caption and an optional │
+│                     │ legend.                                           │
+└─────────────────────┴───────────────────────────────────────────────────┘
+<span class="r2">A &quot;figure&quot; consists of </span><span class="r8">image</span><span class="r2"> data (including </span><span class="r8">image options</span><span class="r2">), an optional caption (a single paragraph), and an optional </span>
+<span class="r2">legend (arbitrary body elements). For page-based output media, figures might float to a different position if this helps</span>
+<span class="r2">the page layout.</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> figure:: picture</span><span class="r4">.</span><span class="r6">png</span><span class="r5">                                                                                             </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :scale: </span><span class="r12">50</span><span class="r6"> </span><span class="r4">%</span><span class="r5">                                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :alt: map to buried treasure</span><span class="r5">                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   This </span><span class="r4">is</span><span class="r6"> the caption of the figure (a simple paragraph)</span><span class="r4">.</span><span class="r5">                                                          </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">There must be blank lines before the caption paragraph and before the legend.  To specify a legend without a caption, </span>
+<span class="r2">use an empty comment (&quot;..&quot;) in place of the caption.</span>
+
+<span class="r2">The &quot;figure&quot; directive supports all of the options of the &quot;image&quot; directive (see </span><span class="r8">image options</span><span class="r2"> above). These options </span>
+<span class="r2">(except &quot;align&quot;) are passed on to the contained image.</span>
+
+    align : <span class="r13">&quot;left&quot;, &quot;center&quot;, or &quot;right&quot;</span>
+      The horizontal alignment of the figure, allowing the image to float and have the text flow around it.  The 
+specific behavior depends upon the browser or rendering software used.
+<span class="r2">In addition, the following options are recognized:</span>
+    figwidth : <span class="r13">&quot;image&quot;, length, or percentage of current line width</span>
+      The width of the figure. Limits the horizontal space used by the figure. A special value of &quot;image&quot; is allowed, in
+which case the included image&#x27;s actual width is used (requires the Python Imaging Library). If the image file is not 
+found or the required software is unavailable, this option is ignored.  Sets the &quot;width&quot; attribute of the &quot;figure&quot; 
+doctree element.  This option does not scale the included image; use the &quot;width&quot; image option for that.
+
+    figclass : <span class="r13">text</span>
+      Set a &quot;classes&quot; attribute value on the figure element.  See the class directive below.
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                    Body Elements                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                        Topic                                                         ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                    </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;topic&quot;                        │
+├─────────────────────┼────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ topic                          │
+├─────────────────────┼────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ One, required (topic title).   │
+├─────────────────────┼────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ class, name                    │
+├─────────────────────┼────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ Interpreted as the topic body. │
+└─────────────────────┴────────────────────────────────┘
+<span class="r2">A topic is like a block quote with a title, or a self-contained section with no subsections.  Use the &quot;topic&quot; directive </span>
+<span class="r2">to indicate a self-contained idea that is separate from the flow of the document. Topics may occur anywhere a section or</span>
+<span class="r2">transition may occur.  Body elements and topics may not contain nested topics.</span>
+
+<span class="r2">The directive&#x27;s sole argument is interpreted as the topic title; the next line must be blank.  All subsequent lines make</span>
+<span class="r2">up the topic body, interpreted as body elements.  For example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> topic:: Topic Title</span><span class="r5">                                                                                              </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">    Subsequent indented lines comprise</span><span class="r5">                                                                              </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">    the body of the topic, </span><span class="r4">and</span><span class="r6"> are</span><span class="r5">                                                                                  </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">    interpreted </span><span class="r14">as</span><span class="r6"> body elements</span><span class="r4">.</span><span class="r5">                                                                                   </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                       Sidebar                                                        ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                      </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;sidebar&quot;                        │
+├─────────────────────┼──────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ sidebar                          │
+├─────────────────────┼──────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ One, optional (sidebar title).   │
+├─────────────────────┼──────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ Possible (see below).            │
+├─────────────────────┼──────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ Interpreted as the sidebar body. │
+└─────────────────────┴──────────────────────────────────┘
+<span class="r2">Sidebars are like miniature, parallel documents that occur inside other documents, providing related or reference </span>
+<span class="r2">material.  A sidebar is typically offset by a border and &quot;floats&quot; to the side of the page; the document&#x27;s main text may </span>
+<span class="r2">flow around it.  Sidebars can also be likened to super-footnotes; their content is outside of the flow of the document&#x27;s</span>
+<span class="r2">main text.</span>
+
+<span class="r2">Sidebars may occur anywhere a section or transition may occur.  Body elements (including sidebars) may not contain </span>
+<span class="r2">nested sidebars.</span>
+
+<span class="r2">The directive&#x27;s sole argument is interpreted as the sidebar title, which may be followed by a subtitle option (see </span>
+<span class="r2">below); the next line must be blank.  All subsequent lines make up the sidebar body, interpreted as body elements.  For </span>
+<span class="r2">example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> sidebar:: Optional Sidebar Title</span><span class="r5">                                                                                 </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :subtitle: Optional Sidebar Subtitle</span><span class="r5">                                                                             </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   Subsequent indented lines comprise</span><span class="r5">                                                                               </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   the body of the sidebar, </span><span class="r4">and</span><span class="r6"> are</span><span class="r5">                                                                                 </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   interpreted </span><span class="r14">as</span><span class="r6"> body elements</span><span class="r4">.</span><span class="r5">                                                                                    </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">The following options are recognized:</span>
+
+    subtitle : <span class="r13">text</span>
+      The sidebar&#x27;s subtitle.
+<span class="r2">and the common options </span><span class="r8">class</span><span class="r2"> and </span><span class="r8">name</span><span class="r2">.</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      Line Block                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r15">╭──────────────────────────────────────────────────── Admonition:  ────────────────────────────────────────────────────╮</span>
+<span class="r15">│ Deprecated  The &quot;line-block&quot; directive is deprecated.  Use the line block syntax instead.                            │</span>
+<span class="r15">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                         </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;line-block&quot;                        │
+├─────────────────────┼─────────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ line_block                          │
+├─────────────────────┼─────────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ None.                               │
+├─────────────────────┼─────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ class, name                         │
+├─────────────────────┼─────────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ Becomes the body of the line block. │
+└─────────────────────┴─────────────────────────────────────┘
+<span class="r2">The &quot;line-block&quot; directive constructs an element where line breaks and initial indentation is significant and inline </span>
+<span class="r2">markup is supported.  It is equivalent to a </span><span class="r8">parsed literal block</span><span class="r2"> with different rendering: typically in an ordinary </span>
+<span class="r2">serif typeface instead of a typewriter/monospaced face, and not automatically indented.  (Have the line-block directive </span>
+<span class="r2">begin a block quote to get an indented line block.)  Line blocks are useful for address blocks and verse (poetry, song </span>
+<span class="r2">lyrics), where the structure of lines is significant.  For example, here&#x27;s a classic:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r7">&quot;To Ma Own Beloved Lassie: A Poem on her 17th Birthday&quot;</span><span class="r6">, by</span><span class="r5">                                                         </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">Ewan McTeagle (</span><span class="r14">for</span><span class="r6"> Lassie O</span><span class="r7">&#x27;Shea):</span><span class="r5">                                                                                  </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">    </span><span class="r4">..</span><span class="r6"> line</span><span class="r4">-</span><span class="r6">block::</span><span class="r5">                                                                                                 </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">        Lend us a couple of bob till Thursday</span><span class="r4">.</span><span class="r5">                                                                      </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">        I</span><span class="r7">&#x27;m absolutely skint.</span><span class="r5">                                                                                       </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">        But I</span><span class="r7">&#x27;m expecting a postal order and I can pay you back</span><span class="r5">                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">            </span><span class="r14">as</span><span class="r6"> soon </span><span class="r14">as</span><span class="r6"> it comes</span><span class="r4">.</span><span class="r5">                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">        Love, Ewan</span><span class="r4">.</span><span class="r5">                                                                                                 </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                 Parsed Literal Block                                                 ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                            </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;parsed-literal&quot;                       │
+├─────────────────────┼────────────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ literal_block                          │
+├─────────────────────┼────────────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ None.                                  │
+├─────────────────────┼────────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ class, name                            │
+├─────────────────────┼────────────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ Becomes the body of the literal block. │
+└─────────────────────┴────────────────────────────────────────┘
+<span class="r2">Unlike an ordinary literal block, the &quot;parsed-literal&quot; directive constructs a literal block where the text is parsed for</span>
+<span class="r2">inline markup. It is equivalent to a </span><span class="r8">line block</span><span class="r2"> with different rendering: typically in a typewriter/monospaced typeface,</span>
+<span class="r2">like an ordinary literal block.  Parsed literal blocks are useful for adding hyperlinks to code examples.</span>
+
+<span class="r2">However, care must be taken with the text, because inline markup is recognized and there is no protection from parsing. </span>
+<span class="r2">Backslash-escapes may be necessary to prevent unintended parsing.  And because the markup characters are removed by the </span>
+<span class="r2">parser, care must also be taken with vertical alignment.  Parsed &quot;ASCII art&quot; is tricky, and extra whitespace may be </span>
+<span class="r2">necessary.</span>
+
+<span class="r2">For example, all the element names in this content model are links:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> parsed</span><span class="r4">-</span><span class="r6">literal::</span><span class="r5">                                                                                                 </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   ( (title_, subtitle_</span><span class="r9">?</span><span class="r6">)</span><span class="r9">?</span><span class="r6">,</span><span class="r5">                                                                                         </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">     decoration_</span><span class="r9">?</span><span class="r6">,</span><span class="r5">                                                                                                  </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">     (docinfo_, transition_</span><span class="r9">?</span><span class="r6">)</span><span class="r9">?</span><span class="r6">,</span><span class="r5">                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">     </span><span class="r9">`</span><span class="r4">%</span><span class="r6">structure</span><span class="r4">.</span><span class="r6">model;</span><span class="r9">`</span><span class="r6">_ )</span><span class="r5">                                                                                         </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                         Code                                                         ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name            </span>┃<span class="r1"> Field Value                            </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type       </span> │ &quot;code&quot;                                 │
+├───────────────────────┼────────────────────────────────────────┤
+│ <span class="r1">Doctree Element      </span> │ literal_block, inline elements         │
+├───────────────────────┼────────────────────────────────────────┤
+│ <span class="r1">Directive Arguments  </span> │ One, optional (formal language).       │
+├───────────────────────┼────────────────────────────────────────┤
+│ <span class="r1">Directive Options    </span> │ name, class, number-lines.             │
+├───────────────────────┼────────────────────────────────────────┤
+│ <span class="r1">Directive Content    </span> │ Becomes the body of the literal block. │
+├───────────────────────┼────────────────────────────────────────┤
+│ <span class="r1">Configuration Setting</span> │ syntax_highlight.                      │
+└───────────────────────┴────────────────────────────────────────┘
+<span class="r2">The &quot;code&quot; directive constructs a literal block. If the code language is specified, the content is parsed by the </span>
+<span class="r8">Pygments</span><span class="r2"> syntax highlighter and tokens are stored in nested </span><a class="r8" href="../doctree.html#inline-elements">inline elements</a><span class="r2"> with class arguments according to their </span>
+<span class="r2">syntactic category. The actual highlighting requires a style-sheet (e.g. one </span><span class="r8">generated by Pygments</span><span class="r2">, see the </span>
+<span class="r8">sandbox/stylesheets</span><span class="r2"> for examples).</span>
+
+<span class="r2">The parsing can be turned off with the </span><a class="r8" href="../../user/config.html#syntax-highlight">syntax_highlight</a><span class="r2"> configuration setting and command line option or by specifying </span>
+<span class="r2">the language as </span><span class="r8">class</span><span class="r2"> option instead of directive argument. This also avoids warnings when </span><a class="r8" href="https://pygments.org/">Pygments</a><span class="r2"> is not installed or </span>
+<span class="r2">the language is not in the </span><a class="r8" href="https://pygments.org/languages/">supported languages and markup formats</a><span class="r2">.</span>
+
+<span class="r2">For inline code, use the </span><a class="r8" href="roles.html#code">&quot;code&quot; role</a><span class="r2">.</span>
+
+<span class="r2">The following options are recognized:</span>
+
+    number-lines : <span class="r13">[integer] (start line number)</span>
+      Precede every line with a line number. The optional argument is the number of the first line (default 1).
+<span class="r2">and the common options </span><span class="r8">class</span><span class="r2"> and </span><span class="r8">name</span><span class="r2">.Example:</span>
+
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r6">The content of the following directive ::</span><span class="r5">                                                                           </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">  </span><span class="r4">..</span><span class="r6"> code:: python</span><span class="r5">                                                                                                  </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">    </span><span class="r14">def</span><span class="r6"> </span><span class="r11">my_function</span><span class="r6">():</span><span class="r5">                                                                                              </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">        </span><span class="r7">&quot;just a test&quot;</span><span class="r5">                                                                                               </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">        print </span><span class="r12">8</span><span class="r4">/</span><span class="r12">2</span><span class="r5">                                                                                                   </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">is</span><span class="r6"> parsed </span><span class="r4">and</span><span class="r6"> marked up </span><span class="r14">as</span><span class="r6"> Python source code</span><span class="r4">.</span><span class="r5">                                                                      </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                         Math                                                         ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name            </span>┃<span class="r1"> Field Value                                          </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type       </span> │ &quot;math&quot;                                               │
+├───────────────────────┼──────────────────────────────────────────────────────┤
+│ <span class="r1">Doctree Element      </span> │ math_block                                           │
+├───────────────────────┼──────────────────────────────────────────────────────┤
+│ <span class="r1">Directive Arguments  </span> │ None.                                                │
+├───────────────────────┼──────────────────────────────────────────────────────┤
+│ <span class="r1">Directive Options    </span> │ class, name                                          │
+├───────────────────────┼──────────────────────────────────────────────────────┤
+│ <span class="r1">Directive Content    </span> │ Becomes the body of the math block.                  │
+│                       │ (Content blocks separated by a blank line are put in │
+│                       │ adjacent math blocks.)                               │
+├───────────────────────┼──────────────────────────────────────────────────────┤
+│ <span class="r1">Configuration Setting</span> │ math_output                                          │
+└───────────────────────┴──────────────────────────────────────────────────────┘
+<span class="r2">The &quot;math&quot; directive inserts blocks with mathematical content (display formulas, equations) into the document. The input</span>
+<span class="r2">format is </span><a class="r8" href="../../ref/rst/mathematics.html">LaTeX math syntax</a><span class="r2"> with support for Unicode symbols, for example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> math::</span><span class="r5">                                                                                                           </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">  Î</span><span class="r9">±</span><span class="r6">_t(i) </span><span class="r4">=</span><span class="r6"> P(O_1, O_2, â</span><span class="r9">€¦</span><span class="r6"> O_t, q_t </span><span class="r4">=</span><span class="r6"> S_i Î</span><span class="r9">»</span><span class="r6">)</span><span class="r5">                                                                      </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">Support is limited to a subset of </span><span class="r16">LaTeX math</span><span class="r2"> by the conversion required for many output formats.  For HTML, the </span>
+<a class="r8" href="../../user/config.html#math-output">math_output</a><span class="r2"> configuration setting (or the corresponding </span><span class="r17">--math-output</span><span class="r2"> command line option) select between alternative </span>
+<span class="r2">output formats with different subsets of supported elements. If a writer does not support math typesetting, the content </span>
+<span class="r2">is inserted verbatim.</span>
+
+<span class="r2">For inline formulas, use the </span><a class="r8" href="roles.html#math">&quot;math&quot; role</a><span class="r2">.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                        Rubric                                                        ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                  </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;rubric&quot;                     │
+├─────────────────────┼──────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ rubric                       │
+├─────────────────────┼──────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ One, required (rubric text). │
+├─────────────────────┼──────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ class, name                  │
+├─────────────────────┼──────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ None.                        │
+└─────────────────────┴──────────────────────────────┘
+<span class="r18">▌ </span><span class="r19">rubric n. 1. a title, heading, or the like, in a manuscript,</span>
+<span class="r19">book, statute, etc., written or printed in red or otherwise</span>
+<span class="r19">distinguished from the rest of the text. ...</span>
+<span class="r20">  - Random House Webster&#x27;s College Dictionary, 1991</span><span class="r2">The &quot;rubric&quot; directive inserts a &quot;rubric&quot; element into the document </span>
+<span class="r2">tree.  A rubric is like an informal heading that doesn&#x27;t correspond to the document&#x27;s structure.</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                       Epigraph                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                                 </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;epigraph&quot;                                  │
+├─────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ block_quote                                 │
+├─────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ None.                                       │
+├─────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ None.                                       │
+├─────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ Interpreted as the body of the block quote. │
+└─────────────────────┴─────────────────────────────────────────────┘
+<span class="r2">An epigraph is an apposite (suitable, apt, or pertinent) short inscription, often a quotation or poem, at the beginning </span>
+<span class="r2">of a document or section.</span>
+
+<span class="r2">The &quot;epigraph&quot; directive produces an &quot;epigraph&quot;-class block quote. For example, this input:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> epigraph::</span><span class="r5">                                                                                                       </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   No matter where you go, there you are</span><span class="r4">.</span><span class="r5">                                                                           </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r4">--</span><span class="r6"> Buckaroo Banzai</span><span class="r5">                                                                                               </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">becomes this document tree fragment:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">&lt;</span><span class="r6">block_quote classes</span><span class="r4">=</span><span class="r7">&quot;epigraph&quot;</span><span class="r4">&gt;</span><span class="r5">                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">    </span><span class="r4">&lt;</span><span class="r6">paragraph</span><span class="r4">&gt;</span><span class="r5">                                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">        No matter where you go, there you are</span><span class="r4">.</span><span class="r5">                                                                      </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">    </span><span class="r4">&lt;</span><span class="r6">attribution</span><span class="r4">&gt;</span><span class="r5">                                                                                                   </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">        Buckaroo Banzai</span><span class="r5">                                                                                             </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      Highlights                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                                 </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;highlights&quot;                                │
+├─────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ block_quote                                 │
+├─────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ None.                                       │
+├─────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ None.                                       │
+├─────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ Interpreted as the body of the block quote. │
+└─────────────────────┴─────────────────────────────────────────────┘
+<span class="r2">Highlights summarize the main points of a document or section, often consisting of a list.</span>
+
+<span class="r2">The &quot;highlights&quot; directive produces a &quot;highlights&quot;-class block quote. See </span><span class="r8">Epigraph</span><span class="r2"> above for an analogous example.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      Pull-Quote                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                                 </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;pull-quote&quot;                                │
+├─────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ block_quote                                 │
+├─────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ None.                                       │
+├─────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ None.                                       │
+├─────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ Interpreted as the body of the block quote. │
+└─────────────────────┴─────────────────────────────────────────────┘
+<span class="r2">A pull-quote is a small selection of text &quot;pulled out and quoted&quot;, typically in a larger typeface.  Pull-quotes are used</span>
+<span class="r2">to attract attention, especially in long articles.</span>
+
+<span class="r2">The &quot;pull-quote&quot; directive produces a &quot;pull-quote&quot;-class block quote. See </span><span class="r8">Epigraph</span><span class="r2"> above for an analogous example.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                  Compound Paragraph                                                  ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                   </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;compound&quot;                    │
+├─────────────────────┼───────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ compound                      │
+├─────────────────────┼───────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ None.                         │
+├─────────────────────┼───────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ class, name                   │
+├─────────────────────┼───────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ Interpreted as body elements. │
+└─────────────────────┴───────────────────────────────┘
+<span class="r2">The &quot;compound&quot; directive is used to create a compound paragraph, which is a single logical paragraph containing multiple</span>
+<span class="r2">physical body elements such as simple paragraphs, literal blocks, tables, lists, etc., instead of directly containing </span>
+<span class="r2">text and inline elements.  For example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> compound::</span><span class="r5">                                                                                                       </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   The </span><span class="r7">&#x27;rm&#x27;</span><span class="r6"> command </span><span class="r4">is</span><span class="r6"> very dangerous</span><span class="r4">.</span><span class="r6">  If you are logged</span><span class="r5">                                                           </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r4">in</span><span class="r6"> </span><span class="r14">as</span><span class="r6"> root </span><span class="r4">and</span><span class="r6"> enter ::</span><span class="r5">                                                                                          </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">       cd </span><span class="r4">/</span><span class="r5">                                                                                                         </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">       rm </span><span class="r4">-</span><span class="r6">rf </span><span class="r4">*</span><span class="r5">                                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   you will erase the entire contents of your file system</span><span class="r4">.</span><span class="r5">                                                          </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">In the example above, a literal block is &quot;embedded&quot; within a sentence that begins in one physical paragraph and ends in </span>
+<span class="r2">another.</span>
+
+<span class="r15">╭─────────────────────────────────────────────────────── Note:  ───────────────────────────────────────────────────────╮</span>
+<span class="r15">│ The &quot;compound&quot; directive is not a generic block-level container like HTML&#x27;s &lt;div&gt; element.  Do not use it only to    │</span>
+<span class="r15">│ group a sequence of elements, or you may get unexpected results.  If you need a generic block-level container,       │</span>
+<span class="r15">│ please use the container directive, described below.                                                                 │</span>
+<span class="r15">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r2">Compound paragraphs are typically rendered as multiple distinct text blocks, with the possibility of variations to </span>
+<span class="r2">emphasize their logical unity:</span>
+
+<span class="r10"> • </span>If paragraphs are rendered with a first-line indent, only the first physical paragraph of a compound paragraph should
+have that indent -- second and further physical paragraphs should omit the indents;
+<span class="r10"> • </span>vertical spacing between physical elements may be reduced;
+<span class="r10"> • </span>and so on.
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      Container                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                          </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;container&quot;                          │
+├─────────────────────┼──────────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ container                            │
+├─────────────────────┼──────────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ One or more, optional (class names). │
+├─────────────────────┼──────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ name                                 │
+├─────────────────────┼──────────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ Interpreted as body elements.        │
+└─────────────────────┴──────────────────────────────────────┘
+<span class="r2">The &quot;container&quot; directive surrounds its contents (arbitrary body elements) with a generic block-level &quot;container&quot; </span>
+<span class="r2">element.  Combined with the optional &quot;</span><span class="r8">classes</span><span class="r2">&quot; attribute argument(s), this is an extension mechanism for users &amp; </span>
+<span class="r2">applications.  For example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> container:: custom</span><span class="r5">                                                                                               </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   This paragraph might be rendered </span><span class="r4">in</span><span class="r6"> a custom way</span><span class="r4">.</span><span class="r5">                                                                </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">Parsing the above results in the following pseudo-XML</span>
+<span class="r3">┌──────────────────────────────────────────────────────── xml ─────────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">&lt;container</span><span class="r6"> </span><span class="r11">classes=</span><span class="r7">&quot;custom&quot;</span><span class="r4">&gt;</span><span class="r5">                                                                                        </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">    </span><span class="r4">&lt;paragraph&gt;</span><span class="r5">                                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">        This paragraph might be rendered in a custom way.</span><span class="r5">                                                           </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">The &quot;container&quot; directive is the equivalent of HTML&#x27;s </span><span class="r17">&lt;div&gt;</span><span class="r2"> element.  It may be used to group a sequence of elements for</span>
+<span class="r2">user- or application-specific purposes.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                        Tables                                                        ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r2">Formal tables need more structure than the reStructuredText syntax supplies.  Tables may be given titles with the </span><a class="r8" href="../doctree.html#table">table</a><span class="r2"> </span>
+<span class="r2">directive. Sometimes reStructuredText tables are inconvenient to write, or table data in a standard format is readily </span>
+<span class="r2">available.  The </span><span class="r8">csv-table</span><span class="r2"> directive supports CSV data.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                        Table                                                         ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                      </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;table&quot;                          │
+├─────────────────────┼──────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ table                            │
+├─────────────────────┼──────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ One, optional (table title).     │
+├─────────────────────┼──────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ Possible (see below).            │
+├─────────────────────┼──────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ A normal reStructuredText table. │
+└─────────────────────┴──────────────────────────────────┘
+<span class="r2">The &quot;table&quot; directive is used to associate a title with a table or specify options, e.g.:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> table:: Truth table </span><span class="r14">for</span><span class="r6"> </span><span class="r7">&quot;not&quot;</span><span class="r5">                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :widths: auto</span><span class="r5">                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r4">=====</span><span class="r6">  </span><span class="r4">=====</span><span class="r5">                                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">     A    </span><span class="r4">not</span><span class="r6"> A</span><span class="r5">                                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r4">=====</span><span class="r6">  </span><span class="r4">=====</span><span class="r5">                                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r14">False</span><span class="r6">  </span><span class="r14">True</span><span class="r5">                                                                                                      </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r14">True</span><span class="r6">   </span><span class="r14">False</span><span class="r5">                                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r4">=====</span><span class="r6">  </span><span class="r4">=====</span><span class="r5">                                                                                                     </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">The following options are recognized:</span>
+
+    align : <span class="r13">&quot;left&quot;, &quot;center&quot;, or &quot;right&quot;</span>
+      The horizontal alignment of the table (new in Docutils 0.13).
+
+    width : <span class="r13">length or percentage</span>
+      Sets the width of the table to the specified length or percentage of the line width.  If omitted, the renderer 
+determines the width of the table based on its contents or the column widths.  
+
+    widths : <span class="r13">&quot;auto&quot;, &quot;grid&quot;, or a list of integers</span>
+      A list of relative column widths. The default is the width of the input columns (in characters).  &quot;auto&quot; delegates
+the determination of column widths to the backend (LaTeX, the HTML browser, ...).  &quot;grid&quot; restores the default, 
+overriding a table_style or class value &quot;colwidths-auto&quot;.
+<span class="r2">Plus the common options </span><span class="r8">class</span><span class="r2"> and </span><span class="r8">name</span><span class="r2">.</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      CSV Table                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                           </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;csv-table&quot;                           │
+├─────────────────────┼───────────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ table                                 │
+├─────────────────────┼───────────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ One, optional (table title).          │
+├─────────────────────┼───────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ Possible (see below).                 │
+├─────────────────────┼───────────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ A CSV (comma-separated values) table. │
+└─────────────────────┴───────────────────────────────────────┘
+<span class="r10">╭───────────────────────────────────────────────────── Warning:  ──────────────────────────────────────────────────────╮</span>
+<span class="r10">│ The &quot;csv-table&quot; directive&#x27;s &quot;:file:&quot; and &quot;:url:&quot; options represent a potential security holes.  They can be disabled │</span>
+<span class="r10">│ with the &quot;file_insertion_enabled&quot; runtime setting.                                                                   │</span>
+<span class="r10">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r2">The &quot;csv-table&quot; directive is used to create a table from CSV (comma-separated values) data.  CSV is a common data format</span>
+<span class="r2">generated by spreadsheet applications and commercial databases.  The data may be internal (an integral part of the </span>
+<span class="r2">document) or external (a separate file).</span>
+
+<span class="r10"> • </span>Block markup and inline markup within cells is supported.  Line ends are recognized within cells.
+<span class="r10"> • </span>There is no support for checking that the number of columns in each row is the same. The directive automatically adds
+empty entries at the end of short rows.  Add &quot;strict&quot; option to verify input?
+<span class="r2">Example:</span>
+
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> csv</span><span class="r4">-</span><span class="r6">table:: Frozen Delights</span><span class="r9">!</span><span class="r5">                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :header: </span><span class="r7">&quot;Treat&quot;</span><span class="r6">, </span><span class="r7">&quot;Quantity&quot;</span><span class="r6">, </span><span class="r7">&quot;Description&quot;</span><span class="r5">                                                                      </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :widths: </span><span class="r12">15</span><span class="r6">, </span><span class="r12">10</span><span class="r6">, </span><span class="r12">30</span><span class="r5">                                                                                              </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r7">&quot;Albatross&quot;</span><span class="r6">, </span><span class="r12">2.99</span><span class="r6">, </span><span class="r7">&quot;On a stick!&quot;</span><span class="r5">                                                                                 </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r7">&quot;Crunchy Frog&quot;</span><span class="r6">, </span><span class="r12">1.49</span><span class="r6">, </span><span class="r7">&quot;If we took the bones out, it wouldn&#x27;t be</span><span class="r5">                                                  </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   crunchy, now would it</span><span class="r9">?</span><span class="r7">&quot;</span><span class="r5">                                                                                          </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r7">&quot;Gannet Ripple&quot;</span><span class="r6">, </span><span class="r12">1.99</span><span class="r6">, </span><span class="r7">&quot;On a stick!&quot;</span><span class="r5">                                                                             </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">The following options are recognized:</span>
+
+    align : <span class="r13">&quot;left&quot;, &quot;center&quot;, or &quot;right&quot;</span>
+      The horizontal alignment of the table. (New in Docutils 0.13)
+
+    delim : <span class="r13">char | &quot;tab&quot; | &quot;space&quot; </span>
+      A one-character string used to separate fields. Defaults to , (comma).  May be specified as a Unicode code point; 
+see the unicode directive for syntax details.
+
+    encoding : <span class="r13">string</span>
+      The text encoding of the external CSV data (file or URL). Defaults to the document&#x27;s input_encoding.
+
+    escape : <span class="r13">char</span>
+      A one-character string used to escape the delimiter or quote characters.  May be specified as a Unicode code 
+point; see the unicode directive for syntax details.  Used when the delimiter is used in an unquoted field, or when 
+quote characters are used within a field.  The default is to double-up the character, e.g. &quot;He said, &quot;&quot;Hi!&quot;&quot;&quot;  Add 
+another possible value, &quot;double&quot;, to explicitly indicate the default case?
+
+    file : <span class="r13">string (newlines removed)</span>
+      The local filesystem path to a CSV data file.
+
+    header : <span class="r13">CSV data</span>
+      Supplemental data for the table header, added independently of and before any header-rows from the main CSV data. 
+Must use the same CSV format as the main CSV data.
+
+    header-rows : <span class="r13">integer</span>
+      The number of rows of CSV data to use in the table header. Defaults to 0.
+
+    keepspace : <span class="r13">flag (empty)</span>
+      Treat whitespace immediately following the delimiter as significant.  The default is to ignore such whitespace.
+
+    quote : <span class="r13">char</span>
+      A one-character string used to quote elements containing the delimiter or which start with the quote character.  
+Defaults to &quot; (quote).  May be specified as a Unicode code point; see the unicode directive for syntax details.
+
+    stub-columns : <span class="r13">integer</span>
+      The number of table columns to use as stubs (row titles, on the left).  Defaults to 0.
+
+    url : <span class="r13">string (whitespace removed)</span>
+      An Internet URL reference to a CSV data file.
+
+    widths : <span class="r13">integer [integer...] or &quot;auto&quot;</span>
+      A list of relative column widths. The default is equal-width columns (100%/#columns).  &quot;auto&quot; delegates the 
+determination of column widths to the backend (LaTeX, the HTML browser, ...).
+
+    width : <span class="r13">length or percentage</span>
+      Sets the width of the table to the specified length or percentage of the line width.  If omitted, the renderer 
+determines the width of the table based on its contents or the column widths.
+<span class="r2">and the common options </span><span class="r8">class</span><span class="r2"> and </span><span class="r8">name</span><span class="r2">.</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      List Table                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                      </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;list-table&quot;                     │
+├─────────────────────┼──────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ table                            │
+├─────────────────────┼──────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ One, optional (table title).     │
+├─────────────────────┼──────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ Possible (see below).            │
+├─────────────────────┼──────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ A uniform two-level bullet list. │
+└─────────────────────┴──────────────────────────────────┘
+<span class="r2">(This is an initial implementation; </span><span class="r8">further ideas</span><span class="r2"> may be implemented in the future.)</span>
+
+<span class="r2">The &quot;list-table&quot; directive is used to create a table from data in a uniform two-level bullet list.  &quot;Uniform&quot; means that</span>
+<span class="r2">each sublist (second-level list) must contain the same number of list items.</span>
+
+<span class="r2">Example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> list</span><span class="r4">-</span><span class="r6">table:: Frozen Delights</span><span class="r9">!</span><span class="r5">                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :widths: </span><span class="r12">15</span><span class="r6"> </span><span class="r12">10</span><span class="r6"> </span><span class="r12">30</span><span class="r5">                                                                                                </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :header</span><span class="r4">-</span><span class="r6">rows: </span><span class="r12">1</span><span class="r5">                                                                                                  </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r4">*</span><span class="r6"> </span><span class="r4">-</span><span class="r6"> Treat</span><span class="r5">                                                                                                        </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">     </span><span class="r4">-</span><span class="r6"> Quantity</span><span class="r5">                                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">     </span><span class="r4">-</span><span class="r6"> Description</span><span class="r5">                                                                                                  </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r4">*</span><span class="r6"> </span><span class="r4">-</span><span class="r6"> Albatross</span><span class="r5">                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">     </span><span class="r4">-</span><span class="r6"> </span><span class="r12">2.99</span><span class="r5">                                                                                                         </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">     </span><span class="r4">-</span><span class="r6"> On a stick</span><span class="r9">!</span><span class="r5">                                                                                                  </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r4">*</span><span class="r6"> </span><span class="r4">-</span><span class="r6"> Crunchy Frog</span><span class="r5">                                                                                                 </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">     </span><span class="r4">-</span><span class="r6"> </span><span class="r12">1.49</span><span class="r5">                                                                                                         </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">     </span><span class="r4">-</span><span class="r6"> If we took the bones out, it wouldn</span><span class="r7">&#x27;t be</span><span class="r5">                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">       crunchy, now would it</span><span class="r9">?</span><span class="r5">                                                                                       </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r4">*</span><span class="r6"> </span><span class="r4">-</span><span class="r6"> Gannet Ripple</span><span class="r5">                                                                                                </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">     </span><span class="r4">-</span><span class="r6"> </span><span class="r12">1.99</span><span class="r5">                                                                                                         </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">     </span><span class="r4">-</span><span class="r6"> On a stick</span><span class="r9">!</span><span class="r5">                                                                                                  </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">The following options are recognized:</span>
+
+    align : <span class="r13">&quot;left&quot;, &quot;center&quot;, or &quot;right&quot;</span>
+      The horizontal alignment of the table. (New in Docutils 0.13)
+
+    header-rows : <span class="r13">integer</span>
+      The number of rows of list data to use in the table header. Defaults to 0.
+
+    stub-columns : <span class="r13">integer</span>
+      The number of table columns to use as stubs (row titles, on the left).  Defaults to 0.  
+
+    width : <span class="r13">length or percentage</span>
+      Sets the width of the table to the specified length or percentage of the line width.  If omitted, the renderer 
+determines the width of the table based on its contents or the column widths.  
+
+    widths : <span class="r13">integer [integer...] or &quot;auto&quot;</span>
+      A list of relative column widths. The default is equal-width columns (100%/#columns).  &quot;auto&quot; delegates the 
+determination of column widths to the backend (LaTeX, the HTML browser, ...).
+<span class="r2">and the common options </span><span class="r8">class</span><span class="r2"> and </span><span class="r8">name</span><span class="r2">.</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                    Document Parts                                                    ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                  Table of Contents                                                   ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value           </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;contents&quot;            │
+├─────────────────────┼───────────────────────┤
+│ <span class="r1">Doctree Elements   </span> │ pending, topic        │
+├─────────────────────┼───────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ One, optional: title. │
+├─────────────────────┼───────────────────────┤
+│ <span class="r1">Directive Options  </span> │ Possible (see below). │
+├─────────────────────┼───────────────────────┤
+│ <span class="r1">Directive Content  </span> │ None.                 │
+└─────────────────────┴───────────────────────┘
+<span class="r2">The &quot;contents&quot; directive generates a table of contents (TOC) in a </span><a class="r8" href="../doctree.html#topic">topic</a><span class="r2">.  Topics, and therefore tables of contents, may </span>
+<span class="r2">occur anywhere a section or transition may occur.  Body elements and topics may not contain tables of contents.</span>
+
+<span class="r2">Here&#x27;s the directive in its simplest form:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> contents::</span><span class="r5">                                                                                                       </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">Language-dependent boilerplate text will be used for the title.  The English default title text is &quot;Contents&quot;.</span>
+
+<span class="r2">An explicit title may be specified:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> contents:: Table of Contents</span><span class="r5">                                                                                     </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">The title may span lines, although it is not recommended:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> contents:: Here</span><span class="r7">&#x27;s a very long Table of</span><span class="r5">                                                                           </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   Contents title</span><span class="r5">                                                                                                   </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">Options may be specified for the directive, using a field list:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> contents:: Table of Contents</span><span class="r5">                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :depth: </span><span class="r12">2</span><span class="r5">                                                                                                        </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">If the default title is to be used, the options field list may begin on the same line as the directive marker:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> contents:: :depth: </span><span class="r12">2</span><span class="r5">                                                                                             </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">The following options are recognized:</span>
+
+    depth : <span class="r13">integer</span>
+      The number of section levels that are collected in the table of contents.  The default is unlimited depth.
+
+    local : <span class="r13">flag (empty)</span>
+      Generate a local table of contents.  Entries will only include subsections of the section in which the directive 
+is given.  If no explicit title is given, the table of contents will not be titled.
+
+    backlinks : <span class="r13">&quot;entry&quot; or &quot;top&quot; or &quot;none&quot;</span>
+      Generate links from section headers back to the table of contents entries, the table of contents itself, or 
+generate no back-links.
+
+    class : <span class="r13">text</span>
+      Set a &quot;classes&quot; attribute value on the topic element.  See the class directive below.
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                             Automatic Section Numbering                                              ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name            </span>┃<span class="r1"> Field Value                                 </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type       </span> │ &quot;sectnum&quot; or &quot;section-numbering&quot; (synonyms) │
+├───────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Doctree Elements     </span> │ pending, generated                          │
+├───────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Directive Arguments  </span> │ None.                                       │
+├───────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Directive Options    </span> │ Possible (see below).                       │
+├───────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Directive Content    </span> │ None.                                       │
+├───────────────────────┼─────────────────────────────────────────────┤
+│ <span class="r1">Configuration Setting</span> │ sectnum_xform                               │
+└───────────────────────┴─────────────────────────────────────────────┘
+<span class="r2">The &quot;sectnum&quot; (or &quot;section-numbering&quot;) directive automatically numbers sections and subsections in a document (if not </span>
+<span class="r2">disabled by the </span><span class="r17">--no-section-numbering</span><span class="r2"> command line option or the </span><a class="r8" href="../../user/config.html#sectnum-xform">sectnum_xform</a><span class="r2"> configuration setting).</span>
+
+<span class="r2">Section numbers are of the &quot;multiple enumeration&quot; form, where each level has a number, separated by periods.  For </span>
+<span class="r2">example, the title of section 1, subsection 2, subsubsection 3 would have &quot;1.2.3&quot; prefixed.</span>
+
+<span class="r2">The &quot;sectnum&quot; directive does its work in two passes: the initial parse and a transform.  During the initial parse, a </span>
+<span class="r2">&quot;pending&quot; element is generated which acts as a placeholder, storing any options internally. At a later stage in the </span>
+<span class="r2">processing, the &quot;pending&quot; element triggers a transform, which adds section numbers to titles.  Section numbers are </span>
+<span class="r2">enclosed in a &quot;generated&quot; element, and titles have their &quot;auto&quot; attribute set to &quot;1&quot;.</span>
+
+<span class="r2">The following options are recognized:</span>
+
+    depth : <span class="r13">integer</span>
+      The number of section levels that are numbered by this directive. The default is unlimited depth.
+
+    prefix : <span class="r13">string</span>
+      An arbitrary string that is prefixed to the automatically generated section numbers.  It may be something like 
+&quot;3.2.&quot;, which will produce &quot;3.2.1&quot;, &quot;3.2.2&quot;, &quot;3.2.2.1&quot;, and so on.  Note that any separating punctuation (in the 
+example, a period, &quot;.&quot;) must be explicitly provided.  The default is no prefix.
+
+    suffix : <span class="r13">string</span>
+      An arbitrary string that is appended to the automatically generated section numbers.  The default is no suffix.
+
+    start : <span class="r13">integer</span>
+      The value that will be used for the first section number. Combined with prefix, this may be used to force the 
+right numbering for a document split over several source files.  The default is 1.
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                               Document Header &amp; Footer                                               ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                   </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Types    </span> │ &quot;header&quot; and &quot;footer&quot;         │
+├─────────────────────┼───────────────────────────────┤
+│ <span class="r1">Doctree Elements   </span> │ decoration, header, footer    │
+├─────────────────────┼───────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ None.                         │
+├─────────────────────┼───────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ None.                         │
+├─────────────────────┼───────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ Interpreted as body elements. │
+└─────────────────────┴───────────────────────────────┘
+<span class="r2">The &quot;header&quot; and &quot;footer&quot; directives create document decorations, useful for page navigation, notes, time/datestamp, </span>
+<span class="r2">etc.  For example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> header:: This space </span><span class="r14">for</span><span class="r6"> rent</span><span class="r4">.</span><span class="r5">                                                                                    </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">This will add a paragraph to the document header, which will appear at the top of the generated web page or at the top </span>
+<span class="r2">of every printed page.</span>
+
+<span class="r2">These directives may be used multiple times, cumulatively.  There is currently support for only one header and footer.</span>
+
+<span class="r15">╭─────────────────────────────────────────────────────── Note:  ───────────────────────────────────────────────────────╮</span>
+<span class="r15">│ While it is possible to use the &quot;header&quot; and &quot;footer&quot; directives to create navigational elements for web pages, you  │</span>
+<span class="r15">│ should be aware that Docutils is meant to be used for document processing, and that a navigation bar is not          │</span>
+<span class="r15">│ typically part of a document.  Thus, you may soon find Docutils&#x27; abilities to be insufficient for these purposes.    │</span>
+<span class="r15">│ At that time, you should consider using a documentation generator like Sphinx rather than the &quot;header&quot; and &quot;footer&quot;  │</span>
+<span class="r15">│ directives.                                                                                                          │</span>
+<span class="r15">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r2">In addition to the use of these directives to populate header and footer content, content may also be added </span>
+<span class="r2">automatically by the processing system.  For example, if certain runtime settings are enabled, the document footer is </span>
+<span class="r2">populated with processing information such as a datestamp, a link to </span><a class="r8" href="https://docutils.sourceforge.io">the Docutils website</a><span class="r2">, etc.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      References                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                   Target Footnotes                                                   ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                           </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;target-notes&quot;                        │
+├─────────────────────┼───────────────────────────────────────┤
+│ <span class="r1">Doctree Elements   </span> │ pending, footnote, footnote_reference │
+├─────────────────────┼───────────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ None.                                 │
+├─────────────────────┼───────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ class, name                           │
+├─────────────────────┼───────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ Possible (see below).                 │
+├─────────────────────┼───────────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ None.                                 │
+└─────────────────────┴───────────────────────────────────────┘
+<span class="r2">The &quot;target-notes&quot; directive creates a footnote for each external target in the text, and corresponding footnote </span>
+<span class="r2">references after each reference.  For every explicit target (of the form, </span><span class="r17">.. _target name: URL</span><span class="r2">) in the text, a footnote </span>
+<span class="r2">will be generated containing the visible URL as content.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      Footnotes                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r1">NOT IMPLEMENTED YET</span>
+
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value    </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;footnotes&quot;    │
+├─────────────────────┼────────────────┤
+│ <span class="r1">Doctree Elements   </span> │ pending, topic │
+├─────────────────────┼────────────────┤
+│ <span class="r1">Directive Arguments</span> │ None?          │
+├─────────────────────┼────────────────┤
+│ <span class="r1">Directive Options  </span> │ Possible?      │
+├─────────────────────┼────────────────┤
+│ <span class="r1">Directive Content  </span> │ None.          │
+└─────────────────────┴────────────────┘
+<span class="r2">@@@</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      Citations                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r1">NOT IMPLEMENTED YET</span>
+
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value    </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;citations&quot;    │
+├─────────────────────┼────────────────┤
+│ <span class="r1">Doctree Elements   </span> │ pending, topic │
+├─────────────────────┼────────────────┤
+│ <span class="r1">Directive Arguments</span> │ None?          │
+├─────────────────────┼────────────────┤
+│ <span class="r1">Directive Options  </span> │ Possible?      │
+├─────────────────────┼────────────────┤
+│ <span class="r1">Directive Content  </span> │ None.          │
+└─────────────────────┴────────────────┘
+<span class="r2">@@@</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                    HTML-Specific                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                       Imagemap                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r1">NOT IMPLEMENTED YET</span>
+
+<span class="r21">Non-standard element: imagemap.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                       Directives for Substitution Definitions                                        ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r2">The directives in this section may only be used in </span><span class="r8">substitution definitions</span><span class="r2">.  They may not be used directly, in </span>
+<span class="r2">standalone context. The </span><a class="r8" href="../doctree.html#image">image</a><span class="r2"> directive may be used both in substitution definitions and in the standalone context.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                   Replacement Text                                                   ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                                    </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;replace&quot;                                      │
+├─────────────────────┼────────────────────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ Text &amp; inline elements                         │
+├─────────────────────┼────────────────────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ None.                                          │
+├─────────────────────┼────────────────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ None.                                          │
+├─────────────────────┼────────────────────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ A single paragraph; may contain inline markup. │
+└─────────────────────┴────────────────────────────────────────────────┘
+<span class="r2">The &quot;replace&quot; directive is used to indicate replacement text for a substitution reference.  It may be used within </span>
+<span class="r8">substitution definitions</span><span class="r2"> only.  For example, this directive can be used to expand abbreviations:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> </span><span class="r4">|</span><span class="r6">reST</span><span class="r4">|</span><span class="r6"> replace:: reStructuredText</span><span class="r5">                                                                                </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">Yes, </span><span class="r4">|</span><span class="r6">reST</span><span class="r4">|</span><span class="r6"> </span><span class="r4">is</span><span class="r6"> a long word, so I can</span><span class="r7">&#x27;t blame anyone for wanting to</span><span class="r5">                                                  </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">abbreviate it</span><span class="r4">.</span><span class="r5">                                                                                                      </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">As reStructuredText doesn&#x27;t support nested inline markup, the only way to create a reference with styled text is to use </span>
+<span class="r2">substitutions with the &quot;replace&quot; directive:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r6">I recommend you </span><span class="r14">try</span><span class="r6"> </span><span class="r4">|</span><span class="r6">Python</span><span class="r4">|</span><span class="r6">_</span><span class="r4">.</span><span class="r5">                                                                                      </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> </span><span class="r4">|</span><span class="r6">Python</span><span class="r4">|</span><span class="r6"> replace:: Python, </span><span class="r4">*</span><span class="r6">the</span><span class="r4">*</span><span class="r6"> best language around</span><span class="r5">                                                            </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> _Python: https:</span><span class="r4">//</span><span class="r6">www</span><span class="r4">.</span><span class="r6">python</span><span class="r4">.</span><span class="r6">org</span><span class="r4">/</span><span class="r5">                                                                                 </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                               Unicode Character Codes                                                ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                                     </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;unicode&quot;                                       │
+├─────────────────────┼─────────────────────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ Text                                            │
+├─────────────────────┼─────────────────────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ One or more, required (Unicode character codes, │
+│                     │ optional text, and comments).                   │
+├─────────────────────┼─────────────────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ Possible (see below).                           │
+├─────────────────────┼─────────────────────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ None.                                           │
+└─────────────────────┴─────────────────────────────────────────────────┘
+<span class="r2">The &quot;unicode&quot; directive converts Unicode character codes (numerical values) to characters, and may be used in </span>
+<span class="r8">substitution definitions</span><span class="r2"> only.</span>
+
+<span class="r2">The arguments, separated by spaces, can be:</span>
+
+  <span class="r10"> ∘ </span>character codes as
+  <span class="r10"> ∘ </span>decimal numbers or  hexadecimal numbers, prefixed by 0x, x, \x, U+, u, or \u or as XML-style hexadecimal character 
+entities, e.g. &amp;#x1a2b;
+    <span class="r10"> ▪ </span>decimal numbers or
+    <span class="r10"> ▪ </span>hexadecimal numbers, prefixed by 0x, x, \x, U+, u, or \u or as XML-style hexadecimal character entities, e.g. &amp;#x
+<span class="r10"> • </span>hexadecimal numbers, prefixed by 0x, x, \x, U+, u, or \u or as XML-style hexadecimal character entities, e.g. &amp;#x1a2b
+<span class="r10"> • </span>text, which is used as-is.
+<span class="r2">Text following &quot; .. &quot; is a comment and is ignored.  The spaces between the arguments are ignored and thus do not appear </span>
+<span class="r2">in the output. Hexadecimal codes are case-insensitive.For example, the following text:</span>
+
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r6">Copyright </span><span class="r4">|</span><span class="r6">copy</span><span class="r4">|</span><span class="r6"> </span><span class="r12">2003</span><span class="r6">, </span><span class="r4">|</span><span class="r6">BogusMegaCorp (TM)</span><span class="r4">|</span><span class="r6"> </span><span class="r4">|---|</span><span class="r5">                                                                   </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">all rights reserved</span><span class="r4">.</span><span class="r5">                                                                                                </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> </span><span class="r4">|</span><span class="r6">copy</span><span class="r4">|</span><span class="r6"> unicode:: </span><span class="r12">0xA9</span><span class="r6"> </span><span class="r4">..</span><span class="r6"> copyright sign</span><span class="r5">                                                                          </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> </span><span class="r4">|</span><span class="r6">BogusMegaCorp (TM)</span><span class="r4">|</span><span class="r6"> unicode:: BogusMegaCorp U</span><span class="r4">+</span><span class="r12">2122</span><span class="r5">                                                              </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r4">..</span><span class="r6"> </span><span class="r14">with</span><span class="r6"> trademark sign</span><span class="r5">                                                                                           </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> </span><span class="r4">|---|</span><span class="r6"> unicode:: U</span><span class="r4">+</span><span class="r12">02014</span><span class="r6"> </span><span class="r4">..</span><span class="r6"> em dash</span><span class="r5">                                                                               </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :trim:</span><span class="r5">                                                                                                           </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">results in:</span>
+
+    <span class="r19">Copyright copy 2003, BogusMegaCorp (TM) --- all rights reserved.</span>
+
+<span class="r2">The following options are recognized:</span>
+    ltrim : <span class="r13">flag (empty)</span>
+      Whitespace to the left of the substitution reference is removed.
+
+    rtrim : <span class="r13">flag (empty)</span>
+      Whitespace to the right of the substitution reference is removed.
+
+    trim : <span class="r13">flag (empty)</span>
+      Equivalent to ltrim plus rtrim; whitespace on both sides of the substitution reference is removed.
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                         Date                                                         ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                  </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;date&quot;                       │
+├─────────────────────┼──────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ Text                         │
+├─────────────────────┼──────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ One, optional (date format). │
+├─────────────────────┼──────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ None.                        │
+├─────────────────────┼──────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ None.                        │
+└─────────────────────┴──────────────────────────────┘
+<span class="r2">The &quot;date&quot; directive generates the current local date and inserts it into the document as text.  This directive may be </span>
+<span class="r2">used in substitution definitions only.</span>
+
+<span class="r2">The optional directive content is interpreted as the desired date format, using the same codes as Python&#x27;s </span>
+<span class="r8">time.strftime()</span><span class="r2"> function.  The default format is &quot;%Y-%m-%d&quot; (ISO 8601 date), but time fields can also be used.  </span>
+<span class="r2">Examples:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> </span><span class="r4">|</span><span class="r6">date</span><span class="r4">|</span><span class="r6"> date::</span><span class="r5">                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> </span><span class="r4">|</span><span class="r6">time</span><span class="r4">|</span><span class="r6"> date:: </span><span class="r4">%</span><span class="r6">H:</span><span class="r4">%</span><span class="r6">M</span><span class="r5">                                                                                              </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">Today</span><span class="r7">&#x27;s date is |date|.</span><span class="r5">                                                                                             </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">This document was generated on </span><span class="r4">|</span><span class="r6">date</span><span class="r4">|</span><span class="r6"> at </span><span class="r4">|</span><span class="r6">time</span><span class="r4">|.</span><span class="r5">                                                                    </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                    Miscellaneous                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                       Including an External Document Fragment                                        ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name            </span>┃<span class="r1"> Field Value                                  </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type       </span> │ &quot;include&quot;                                    │
+├───────────────────────┼──────────────────────────────────────────────┤
+│ <span class="r1">Doctree Elements     </span> │ Depend on data being included                │
+│                       │ (literal_block with code or literal option). │
+├───────────────────────┼──────────────────────────────────────────────┤
+│ <span class="r1">Directive Arguments  </span> │ One, required (path to the file to include). │
+├───────────────────────┼──────────────────────────────────────────────┤
+│ <span class="r1">Directive Options    </span> │ Possible (see below).                        │
+├───────────────────────┼──────────────────────────────────────────────┤
+│ <span class="r1">Directive Content    </span> │ None.                                        │
+├───────────────────────┼──────────────────────────────────────────────┤
+│ <span class="r1">Configuration Setting</span> │ file_insertion_enabled                       │
+└───────────────────────┴──────────────────────────────────────────────┘
+<span class="r10">╭───────────────────────────────────────────────────── Warning:  ──────────────────────────────────────────────────────╮</span>
+<span class="r10">│ The &quot;include&quot; directive represents a potential security hole.  It can be disabled with the &quot;file_insertion_enabled&quot;  │</span>
+<span class="r10">│ runtime setting.                                                                                                     │</span>
+<span class="r10">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r2">The &quot;include&quot; directive reads a text file. The directive argument is the path to the file to be included, relative to </span>
+<span class="r2">the document containing the directive. Unless the options </span><span class="r17">literal</span><span class="r2">, </span><span class="r17">code</span><span class="r2">, or </span><span class="r17">parser</span><span class="r2"> are given, the file is parsed in the </span>
+<span class="r2">current document&#x27;s context at the point of the directive. For example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r6">This first example will be parsed at the document level, </span><span class="r4">and</span><span class="r6"> can</span><span class="r5">                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">thus contain any construct, including section headers</span><span class="r4">.</span><span class="r5">                                                              </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> include:: inclusion</span><span class="r4">.</span><span class="r6">txt</span><span class="r5">                                                                                          </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">Back </span><span class="r4">in</span><span class="r6"> the main document</span><span class="r4">.</span><span class="r5">                                                                                          </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">    This second example will be parsed </span><span class="r4">in</span><span class="r6"> a block quote context</span><span class="r4">.</span><span class="r5">                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">    Therefore it may only contain body elements</span><span class="r4">.</span><span class="r6">  It may </span><span class="r4">not</span><span class="r5">                                                        </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">    contain section headers</span><span class="r4">.</span><span class="r5">                                                                                        </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">    </span><span class="r4">..</span><span class="r6"> include:: inclusion</span><span class="r4">.</span><span class="r6">txt</span><span class="r5">                                                                                      </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">If an included document fragment contains section structure, the title adornments must match those of the master </span>
+<span class="r2">document.</span>
+
+<span class="r2">Standard data files intended for inclusion in reStructuredText documents are distributed with the Docutils source code, </span>
+<span class="r2">located in the &quot;docutils&quot; package in the </span><span class="r17">docutils/parsers/rst/include</span><span class="r2"> directory.  To access these files, use the special</span>
+<span class="r2">syntax for standard &quot;include&quot; data files, angle brackets around the file name:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> include:: </span><span class="r4">&lt;</span><span class="r6">isonum</span><span class="r4">.</span><span class="r6">txt</span><span class="r4">&gt;</span><span class="r5">                                                                                           </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">The current set of standard &quot;include&quot; data files consists of sets of substitution definitions.  See </span><span class="r8">reStructuredText </span>
+<span class="r8">Standard Definition Files</span><span class="r2"> for details.</span>
+
+<span class="r2">The following options are recognized:</span>
+
+    start-line : <span class="r13">integer</span>
+      Only the content starting from this line will be included. (As usual in Python, the first line has index 0 and 
+negative values count from the end.)
+
+    end-line : <span class="r13">integer</span>
+      Only the content up to (but excluding) this line will be included.
+
+    start-after : <span class="r13">text to find in the external data file</span>
+      Only the content after the first occurrence of the specified text will be included.
+
+    end-before : <span class="r13">text to find in the external data file</span>
+      Only the content before the first occurrence of the specified text (but after any after text) will be included.
+
+    parser : <span class="r13">parser name</span>
+      Parse the included content with the specified parser. (New in Docutils 0.17)
+
+    literal : <span class="r13">flag (empty)</span>
+      The entire included text is inserted into the document as a single literal block.
+
+    code : <span class="r13">[string] (formal language)</span>
+      The argument and the included content are passed to the code directive (useful for program listings).
+
+    number-lines : <span class="r13">[integer] (start line number)</span>
+      Precede every code line with a line number. The optional argument is the number of the first line (default 1). 
+Works only with code or literal.
+
+    encoding : <span class="r13">string</span>
+      The text encoding of the external data file.  Defaults to the document&#x27;s input_encoding.  
+
+    tab-width : <span class="r13">integer</span>
+      Number of spaces for hard tab expansion. A negative value prevents expansion of hard tabs. Defaults to the 
+tab_width configuration setting.  
+<span class="r2">With </span><span class="r17">code</span><span class="r2"> or </span><span class="r17">literal</span><span class="r2"> the common options </span><span class="r8">class</span><span class="r2"> and </span><span class="r8">name</span><span class="r2"> are recognized as well.Combining </span><span class="r17">start/end-line</span><span class="r2"> and </span>
+<span class="r17">start-after/end-before</span><span class="r2"> is possible. The text markers will be searched in the specified lines (further limiting the </span>
+<span class="r2">included content).</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                Raw Data Pass-Through                                                 ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name            </span>┃<span class="r1"> Field Value                                        </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type       </span> │ &quot;raw&quot;                                              │
+├───────────────────────┼────────────────────────────────────────────────────┤
+│ <span class="r1">Doctree Element      </span> │ raw                                                │
+├───────────────────────┼────────────────────────────────────────────────────┤
+│ <span class="r1">Directive Arguments  </span> │ One or more, required (output format types).       │
+├───────────────────────┼────────────────────────────────────────────────────┤
+│ <span class="r1">Directive Options    </span> │ Possible (see below).                              │
+├───────────────────────┼────────────────────────────────────────────────────┤
+│ <span class="r1">Directive Content    </span> │ Stored verbatim, uninterpreted.  None (empty) if a │
+│                       │ &quot;file&quot; or &quot;url&quot; option given.                      │
+├───────────────────────┼────────────────────────────────────────────────────┤
+│ <span class="r1">Configuration Setting</span> │ raw_enabled                                        │
+└───────────────────────┴────────────────────────────────────────────────────┘
+<span class="r10">╭───────────────────────────────────────────────────── Warning:  ──────────────────────────────────────────────────────╮</span>
+<span class="r10">│ The &quot;raw&quot; directive represents a potential security hole.  It can be disabled with the &quot;raw_enabled&quot; or              │</span>
+<span class="r10">│ &quot;file_insertion_enabled&quot; runtime settings.                                                                           │</span>
+<span class="r10">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r22">╭───────────────────────────────────────────────────── Caution:  ──────────────────────────────────────────────────────╮</span>
+<span class="r22">│ The &quot;raw&quot; directive is a stop-gap measure allowing the author to bypass reStructuredText&#x27;s markup.  It is a          │</span>
+<span class="r22">│ &quot;power-user&quot; feature that should not be overused or abused.  The use of &quot;raw&quot; ties documents to specific output      │</span>
+<span class="r22">│ formats and makes them less portable.  If you often need to use the &quot;raw&quot; directive or a &quot;raw&quot;-derived interpreted   │</span>
+<span class="r22">│ text role, that is a sign either of overuse/abuse or that functionality may be missing from reStructuredText.        │</span>
+<span class="r22">│ Please describe your situation in a message to the Docutils-users mailing list.                                      │</span>
+<span class="r22">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r2">The &quot;raw&quot; directive indicates non-reStructuredText data that is to be passed untouched to the Writer.  The names of the </span>
+<span class="r2">output formats are given in the directive arguments.  The interpretation of the raw data is up to the Writer.  A Writer </span>
+<span class="r2">may ignore any raw output not matching its format.</span>
+
+<span class="r2">For example, the following input would be passed untouched by an HTML Writer:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> raw:: html</span><span class="r5">                                                                                                       </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   </span><span class="r4">&lt;</span><span class="r6">hr width</span><span class="r4">=</span><span class="r12">50</span><span class="r6"> size</span><span class="r4">=</span><span class="r12">10</span><span class="r4">&gt;</span><span class="r5">                                                                                            </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">A LaTeX Writer could insert the following raw content into its output stream:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> raw:: latex</span><span class="r5">                                                                                                      </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   \setlength{\parindent}{</span><span class="r12">0</span><span class="r6">pt}</span><span class="r5">                                                                                      </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">Raw data can also be read from an external file, specified in a directive option.  In this case, the content block must </span>
+<span class="r2">be empty.  For example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> raw:: html</span><span class="r5">                                                                                                       </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :file: inclusion</span><span class="r4">.</span><span class="r6">html</span><span class="r5">                                                                                            </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">Inline equivalents of the &quot;raw&quot; directive can be defined via </span><span class="r8">custom interpreted text roles</span><span class="r2"> derived from the </span><a class="r8" href="roles.html#raw">&quot;raw&quot; role</a><span class="r2">.</span>
+
+<span class="r2">The following options are recognized:</span>
+
+    file : <span class="r13">string (newlines removed)</span>
+      The local filesystem path of a raw data file to be included.
+
+    url : <span class="r13">string (whitespace removed)</span>
+      An Internet URL reference to a raw data file to be included.
+
+    encoding : <span class="r13">string</span>
+      The text encoding of the external raw data (file or URL). Defaults to the document&#x27;s encoding (if specified).
+<span class="r2">and the common option </span><span class="r8">class</span><span class="r2">.</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                        Class                                                         ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                                      </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;class&quot;                                          │
+├─────────────────────┼──────────────────────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ pending                                          │
+├─────────────────────┼──────────────────────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ One or more, required (class names / attribute   │
+│                     │ values).                                         │
+├─────────────────────┼──────────────────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ None.                                            │
+├─────────────────────┼──────────────────────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ Optional.  If present, it is interpreted as body │
+│                     │ elements.                                        │
+└─────────────────────┴──────────────────────────────────────────────────┘
+<span class="r2">The &quot;class&quot; directive sets the </span><span class="r8">&quot;classes&quot;</span><span class="r2"> attribute value on its content or on the first immediately following  </span>
+<span class="r2">non-comment element . The directive argument consists of one or more space-separated class names. The names are </span>
+<span class="r2">transformed to conform to the regular expression </span><span class="r17">[a-z](-?[a-z0-9]+)*</span><span class="r2"> (see </span><span class="r8">Identifier Normalization</span><span class="r2"> below).</span>
+
+<span class="r2">Examples:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> class:: special</span><span class="r5">                                                                                                  </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">This </span><span class="r4">is</span><span class="r6"> a </span><span class="r7">&quot;special&quot;</span><span class="r6"> paragraph</span><span class="r4">.</span><span class="r5">                                                                                      </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> class:: exceptional remarkable</span><span class="r5">                                                                                   </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">An Exceptional Section</span><span class="r5">                                                                                              </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">======================</span><span class="r5">                                                                                              </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">This </span><span class="r4">is</span><span class="r6"> an ordinary paragraph</span><span class="r4">.</span><span class="r5">                                                                                      </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> class:: multiple</span><span class="r5">                                                                                                 </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   First paragraph</span><span class="r4">.</span><span class="r5">                                                                                                 </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   Second paragraph</span><span class="r4">.</span><span class="r5">                                                                                                </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">The text above is parsed and transformed into this doctree fragment:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> code</span><span class="r4">-</span><span class="r6">block:: xml</span><span class="r5">                                                                                                 </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+    <span class="r19">&lt;paragraph classes=&quot;special&quot;&gt;  This is a &quot;special&quot; paragraph.  &lt;section classes=&quot;exceptional remarkable&quot;&gt;  &lt;title&gt;  </span>
+<span class="r19">An Exceptional Section  &lt;paragraph&gt;  This is an ordinary paragraph.  &lt;paragraph classes=&quot;multiple&quot;&gt;  First paragraph.  </span>
+<span class="r19">&lt;paragraph classes=&quot;multiple&quot;&gt;  Second paragraph.</span>
+
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                               Identifier Normalization                                               ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r2">Docutils </span><a class="r8" href="../doctree.html#classnames-type">class names</a><span class="r2"> and </span><a class="r8" href="../doctree.html#ids-type">identifier keys</a><span class="r2"> are normalized to conform to the regular expression &quot;</span><span class="r17">[a-z](-?[a-z0-9]+)*</span><span class="r2">&quot; by </span>
+<span class="r2">converting</span>
+
+<span class="r10"> • </span>alphabetic characters to lowercase,
+<span class="r10"> • </span>accented characters to the base character,
+<span class="r10"> • </span>non-alphanumeric characters to hyphens,
+<span class="r10"> • </span>consecutive hyphens into one hyphen
+<span class="r2">and stripping</span>
+<span class="r10"> • </span>leading hyphens and number characters, and
+<span class="r10"> • </span>trailing hyphens.
+<span class="r2">For example </span><span class="r17">&quot;Rot.Gelb&amp;GrÃ¼n:+2008&quot;</span><span class="r2"> becomes </span><span class="r17">&quot;rot-gelb-grun-2008&quot;</span><span class="r2"> and </span><span class="r17">&quot;1000_Steps!&quot;</span><span class="r2"> becomes </span><span class="r17">&quot;steps&quot;</span><span class="r2">.</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      Rationale:                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r2">Identifier keys must be valid in all supported output formats.</span>
+
+<span class="r2">For HTMLÂ 4.1 + CSS1 compatibility, identifiers should have no underscores, colons, or periods.  Hyphens may be used.</span>
+
+<span class="r10"> • </span>The HTML 4.01 spec defines identifiers based on SGML tokens:  ID and NAME tokens must begin with a letter ([A-Za-z]) 
+may be followed by any number of letters, digits ([0-9]), hyphens (&quot;-&quot;), underscores (&quot;_&quot;), colons (&quot;:&quot;), and periods 
+(&quot;.&quot;).  https://www.w3.org/TR/html401/types.html#type-name
+<span class="r10"> • </span>The CSS1 spec defines identifiers based on the &quot;name&quot; token (&quot;flex&quot; tokenizer notation below; &quot;latin1&quot; and &quot;escape&quot; 
+8-bit characters have been replaced with XML entities):  unicode     \\[0-9a-f]{1,4} latin1      [&amp;iexcl;-&amp;yuml;] escape
+{unicode}|\\[ -~&amp;iexcl;-&amp;yuml;] nmchar      [-A-Za-z0-9]|{latin1}|{escape} name        {nmchar}+
+<span class="r2">The CSS1 rule requires underscores (&quot;_&quot;), colons (&quot;:&quot;), and periods (&quot;.&quot;) to be escaped , therefore </span><span class="r8">&quot;classes&quot;</span><span class="r2"> and </span><a class="r8" href="../doctree.html#ids">&quot;ids&quot;</a><span class="r2"> </span>
+<span class="r2">attributes should not contain these characters.  Combined with HTML4.1 requirements (the first character must be a </span>
+<span class="r2">letter; no &quot;unicode&quot;, &quot;latin1&quot;, or &quot;escape&quot; characters), this results in the regular expression </span><span class="r17">[A-Za-z][-A-Za-z0-9]*</span><span class="r2">. </span>
+<span class="r2">Docutils adds a normalization by downcasing and merge of consecutive hyphens.</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                            Custom Interpreted Text Roles                                             ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                                     </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;role&quot;                                          │
+├─────────────────────┼─────────────────────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ None; affects subsequent parsing.               │
+├─────────────────────┼─────────────────────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ Two; one required (new role name), one optional │
+│                     │ (base role name, in parentheses).               │
+├─────────────────────┼─────────────────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ Possible (depends on base role).                │
+├─────────────────────┼─────────────────────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ depends on base role.                           │
+└─────────────────────┴─────────────────────────────────────────────────┘
+<span class="r2">The &quot;role&quot; directive dynamically creates a custom </span><a class="r8" href="roles.html">interpreted text role</a><span class="r2"> and registers it with the parser.  This means </span>
+<span class="r2">that after declaring a role like this:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> role:: custom</span><span class="r5">                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">the document may use the new &quot;custom&quot; role:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r6">An example of using :custom:</span><span class="r9">`</span><span class="r6">interpreted text</span><span class="r9">`</span><span class="r5">                                                                      </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">This will be parsed into the following document tree fragment:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> code</span><span class="r4">-</span><span class="r6">block:: xml</span><span class="r5">                                                                                                 </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+    <span class="r19">&lt;paragraph&gt;  An example of using &lt;inline classes=&quot;custom&quot;&gt;  &lt;rst-document&gt;:1726: (ERROR/3) Unexpected indentation.  </span>
+<span class="r19">interpreted text</span>
+
+<span class="r2">The role must be declared in a document before it can be used.Role names are case insensitive and must conform to the </span>
+<span class="r2">rules of simple </span><a class="r8" href="restructuredtext.html#reference-names">reference names</a><span class="r2"> (but do not share a namespace with hyperlinks, footnotes, and citations).The new role </span>
+<span class="r2">may be based on an existing role, specified as a second argument in parentheses (whitespace optional):</span>
+
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> role:: custom(emphasis)</span><span class="r5">                                                                                          </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">:custom:</span><span class="r9">`</span><span class="r6">text</span><span class="r9">`</span><span class="r5">                                                                                                      </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">The parsed result is as follows:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> code</span><span class="r4">-</span><span class="r6">block:: xml</span><span class="r5">                                                                                                 </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+    <span class="r19">&lt;paragraph&gt;  &lt;emphasis classes=&quot;custom&quot;&gt;  text</span>
+
+<span class="r2">A special case is the </span><span class="r8">&quot;raw&quot; role</span><span class="r2">: derived roles enable inline </span><span class="r8">raw data pass-through</span><span class="r2">, e.g.:</span>
+
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> role:: raw</span><span class="r4">-</span><span class="r6">role(raw)</span><span class="r5">                                                                                             </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :format: html latex</span><span class="r5">                                                                                              </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">:raw</span><span class="r4">-</span><span class="r6">role:</span><span class="r9">`</span><span class="r6">raw text</span><span class="r9">`</span><span class="r5">                                                                                                </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">If no base role is explicitly specified, a generic custom role is automatically used.  Subsequent interpreted text will </span>
+<span class="r2">produce an &quot;inline&quot; element with a </span><a class="r8" href="../doctree.html#classes">&quot;classes&quot;</a><span class="r2"> attribute, as in the first example above.</span>
+
+<span class="r2">With most roles, the &quot;:class:&quot; option can be used to set a &quot;classes&quot; attribute that is different from the role name.  </span>
+<span class="r2">For example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> role:: custom</span><span class="r5">                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :class: special</span><span class="r5">                                                                                                  </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r5">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">:custom:</span><span class="r9">`</span><span class="r6">interpreted text</span><span class="r9">`</span><span class="r5">                                                                                          </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">This is the parsed result:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> code</span><span class="r4">-</span><span class="r6">block:: xml</span><span class="r5">                                                                                                 </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+    <span class="r19">&lt;paragraph&gt;  &lt;inline classes=&quot;special&quot;&gt;  interpreted text</span>
+
+<span class="r2">The following option is recognized by the &quot;role&quot; directive for most base roles:</span>
+    class : <span class="r13">text</span>
+      Set the &quot;classes&quot; attribute value on the element produced (inline, or element associated with a base class) when 
+the custom interpreted text role is used.  If no directive options are specified, a &quot;class&quot; option with the directive 
+argument (role name) as the value is implied.  See the class directive above.
+<span class="r2">Specific base roles may support other options and/or directive content.  See the </span><a class="r8" href="roles.html">reStructuredText Interpreted Text Roles</a>
+<span class="r2">document for details.</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                      Setting the Default Interpreted Text Role                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                            </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;default-role&quot;                         │
+├─────────────────────┼────────────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ None; affects subsequent parsing.      │
+├─────────────────────┼────────────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ One, optional (new default role name). │
+├─────────────────────┼────────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ None.                                  │
+├─────────────────────┼────────────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ None.                                  │
+└─────────────────────┴────────────────────────────────────────┘
+<span class="r2">The &quot;default-role&quot; directive sets the default interpreted text role, the role that is used for interpreted text without </span>
+<span class="r2">an explicit role. For example, after setting the default role like this:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> default</span><span class="r4">-</span><span class="r6">role:: subscript</span><span class="r5">                                                                                         </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">any subsequent use of implicit-role interpreted text in the document will use the &quot;subscript&quot; role:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r6">An example of a </span><span class="r9">`</span><span class="r6">default</span><span class="r9">`</span><span class="r6"> role</span><span class="r4">.</span><span class="r5">                                                                                     </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">This will be parsed into the following document tree fragment</span>
+<span class="r3">┌──────────────────────────────────────────────────────── xml ─────────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">&lt;paragraph&gt;</span><span class="r5">                                                                                                         </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">    An example of a</span><span class="r5">                                                                                                 </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">    </span><span class="r4">&lt;subscript&gt;</span><span class="r5">                                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">        default</span><span class="r5">                                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">     role.</span><span class="r5">                                                                                                          </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">Custom roles may be used (see the &quot;</span><span class="r8">role</span><span class="r2">&quot; directive above), but it must have been declared in a document before it can be</span>
+<span class="r2">set as the default role.  See the </span><span class="r8">reStructuredText Interpreted Text Roles</span><span class="r2"> document for details of built-in roles.</span>
+
+<span class="r2">The directive may be used without an argument to restore the initial default interpreted text role, which is </span>
+<span class="r2">application-dependent.  The initial default interpreted text role of the standard reStructuredText parser is </span>
+<span class="r2">&quot;title-reference&quot;.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                       Metadata                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                     </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;meta&quot;                          │
+├─────────────────────┼─────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ meta                            │
+├─────────────────────┼─────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ None.                           │
+├─────────────────────┼─────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ None.                           │
+├─────────────────────┼─────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ Must contain a flat field list. │
+└─────────────────────┴─────────────────────────────────┘
+<span class="r2">The &quot;meta&quot; directive is used to specify metadata to be stored in, e.g., </span><a class="r8" href="https://html.spec.whatwg.org/multipage/semantics.html#the-meta-element">HTML meta elements</a><span class="r2"> or as </span><a class="r8" href="https://en.wikipedia.org/wiki/OpenDocument_technical_specification#Metadata">ODT file properties</a><span class="r2">. </span>
+<span class="r2">The LaTeX writer passes it to the </span><span class="r17">pdfinfo</span><span class="r2"> option of the </span><a class="r8" href="https://ctan.org/pkg/hyperref">hyperref</a><span class="r2"> package. If an output format does not support </span>
+<span class="r2">&quot;invisible&quot; metadata, content is silently dropped by the writer.</span>
+
+<span class="r15">╭─────────────────────────────────────────────────────── Note:  ───────────────────────────────────────────────────────╮</span>
+<span class="r15">│ Data from some bibliographic fields is automatically extracted and stored as metadata, too. However, Bibliographic   │</span>
+<span class="r15">│ Fields are also displayed in the document&#x27;s screen rendering or printout.  For an &quot;invisible&quot; document title, see    │</span>
+<span class="r15">│ the metadata document title directive below.                                                                         │</span>
+<span class="r15">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r2">Within the directive block, a flat field list provides the syntax for metadata.  The field name becomes the contents of </span>
+<span class="r2">the &quot;name&quot; attribute of the META tag, and the field body (interpreted as a single string without inline markup) becomes </span>
+<span class="r2">the contents of the &quot;content&quot; attribute.  For example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> meta::</span><span class="r5">                                                                                                           </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :description: The reStructuredText plaintext markup language</span><span class="r5">                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :keywords: plaintext, markup language</span><span class="r5">                                                                            </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">This would be converted to the following HTML</span>
+<span class="r3">┌──────────────────────────────────────────────────────── html ────────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r6">&lt;</span><span class="r4">meta</span><span class="r6"> </span><span class="r11">name</span><span class="r4">=</span><span class="r7">&quot;description&quot;</span><span class="r5">                                                                                            </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">    </span><span class="r11">content</span><span class="r4">=</span><span class="r7">&quot;The reStructuredText plaintext markup language&quot;</span><span class="r6">&gt;</span><span class="r5">                                                       </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">&lt;</span><span class="r4">meta</span><span class="r6"> </span><span class="r11">name</span><span class="r4">=</span><span class="r7">&quot;keywords&quot;</span><span class="r6"> </span><span class="r11">content</span><span class="r4">=</span><span class="r7">&quot;plaintext, markup language&quot;</span><span class="r6">&gt;</span><span class="r5">                                                         </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">Support for other META attributes (&quot;http-equiv&quot;, &quot;scheme&quot;, &quot;lang&quot;, &quot;dir&quot;) are provided through field arguments, which </span>
+<span class="r2">must be of the form &quot;attr=value&quot;:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> meta::</span><span class="r5">                                                                                                           </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :description lang</span><span class="r4">=</span><span class="r6">en: An amusing story</span><span class="r5">                                                                           </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :description lang</span><span class="r4">=</span><span class="r6">fr: Une histoire amusante</span><span class="r5">                                                                      </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">And their HTML equivalents</span>
+<span class="r3">┌──────────────────────────────────────────────────────── html ────────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r6">&lt;</span><span class="r4">meta</span><span class="r6"> </span><span class="r11">name</span><span class="r4">=</span><span class="r7">&quot;description&quot;</span><span class="r6"> </span><span class="r11">lang</span><span class="r4">=</span><span class="r7">&quot;en&quot;</span><span class="r6"> </span><span class="r11">content</span><span class="r4">=</span><span class="r7">&quot;An amusing story&quot;</span><span class="r6">&gt;</span><span class="r5">                                                      </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">&lt;</span><span class="r4">meta</span><span class="r6"> </span><span class="r11">name</span><span class="r4">=</span><span class="r7">&quot;description&quot;</span><span class="r6"> </span><span class="r11">lang</span><span class="r4">=</span><span class="r7">&quot;fr&quot;</span><span class="r6"> </span><span class="r11">content</span><span class="r4">=</span><span class="r7">&quot;Une histoire amusante&quot;</span><span class="r6">&gt;</span><span class="r5">                                                 </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">Some META tags use an &quot;http-equiv&quot; attribute instead of the &quot;name&quot; attribute.  To specify &quot;http-equiv&quot; META tags, simply</span>
+<span class="r2">omit the name:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">..</span><span class="r6"> meta::</span><span class="r5">                                                                                                           </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">   :http</span><span class="r4">-</span><span class="r6">equiv</span><span class="r4">=</span><span class="r6">Content</span><span class="r4">-</span><span class="r6">Type: text</span><span class="r4">/</span><span class="r6">html; charset</span><span class="r4">=</span><span class="r6">ISO</span><span class="r4">-</span><span class="r12">8859</span><span class="r4">-</span><span class="r12">1</span><span class="r5">                                                          </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">HTML equivalent</span>
+<span class="r3">┌──────────────────────────────────────────────────────── html ────────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r6">&lt;</span><span class="r4">meta</span><span class="r6"> </span><span class="r11">http-equiv</span><span class="r4">=</span><span class="r7">&quot;Content-Type&quot;</span><span class="r5">                                                                                     </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r6">     </span><span class="r11">content</span><span class="r4">=</span><span class="r7">&quot;text/html; charset=ISO-8859-1&quot;</span><span class="r6">&gt;</span><span class="r5">                                                                       </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                               Metadata Document Title                                                ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                          </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;title&quot;                              │
+├─────────────────────┼──────────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ Sets the document&#x27;s title attribute. │
+├─────────────────────┼──────────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ One, required (the title text).      │
+├─────────────────────┼──────────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ None.                                │
+├─────────────────────┼──────────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ None.                                │
+└─────────────────────┴──────────────────────────────────────┘
+<span class="r2">The &quot;title&quot; directive specifies the document title as metadata, which does not become part of the document body. It </span>
+<span class="r2">overrides the document-supplied </span><a class="r8" href="restructuredtext.html#document-title">document title</a><span class="r2"> and the </span><a class="r8" href="../../user/config.html#title">&quot;title&quot; configuration setting</a><span class="r2">. For example, in HTML output the </span>
+<span class="r2">metadata document title appears in the title bar of the browser window.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                           Restructuredtext-Test-Directive                                            ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name          </span>┃<span class="r1"> Field Value                       </span>┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Directive Type     </span> │ &quot;restructuredtext-test-directive&quot; │
+├─────────────────────┼───────────────────────────────────┤
+│ <span class="r1">Doctree Element    </span> │ system_warning                    │
+├─────────────────────┼───────────────────────────────────┤
+│ <span class="r1">Directive Arguments</span> │ None.                             │
+├─────────────────────┼───────────────────────────────────┤
+│ <span class="r1">Directive Options  </span> │ None.                             │
+├─────────────────────┼───────────────────────────────────┤
+│ <span class="r1">Directive Content  </span> │ Interpreted as a literal block.   │
+└─────────────────────┴───────────────────────────────────┘
+<span class="r2">This directive is provided for test purposes only.  (Nobody is expected to type in a name </span><span class="r16">that</span><span class="r2"> long!)  It is converted </span>
+<span class="r2">into a level-1 (info) system message showing the directive data, possibly followed by a literal block containing the </span>
+<span class="r2">rest of the directive block.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                    Common Options                                                    ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r2">Most of the directives that generate doctree elements support the following options:</span>
+
+    class : <span class="r13">text (space separated list of class names)</span>
+      Set a &quot;classes&quot; attribute value on the doctree element generated by the directive. See also the class directive.  
+
+    name : <span class="r13">text</span>
+      Add text to the &quot;names&quot; attribute of the doctree element generated by the directive. This allows hyperlink 
+references to the element using text as reference name.  Specifying the name option of a directive, e.g.,  .. image:: 
+bild.png    :name: my picture  is a concise syntax alternative to preceding it with a hyperlink target  .. _my picture: 
+.. image:: bild.png
+
+<span class="r23">╭───────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 982); ─────────────────────────────────╮</span>
+<span class="r23">│</span> <span class="r1">&lt;</span><span class="r24">rst-document</span><span class="r1">&gt;</span>:<span class="r23">982</span>: <span class="r1">(</span>INFO/<span class="r23">1</span><span class="r1">)</span> Duplicate implicit target name: <span class="r25">&quot;contents&quot;</span>.                                             <span class="r23">│</span>
+<span class="r23">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r23">╭──────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 1965); ─────────────────────────────────╮</span>
+<span class="r23">│</span> <span class="r1">&lt;</span><span class="r24">rst-document</span><span class="r1">&gt;</span>:<span class="r23">1965</span>: <span class="r1">(</span>INFO/<span class="r23">1</span><span class="r1">)</span> Duplicate implicit target name: <span class="r25">&quot;class&quot;</span>.                                               <span class="r23">│</span>
+<span class="r23">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r23">╭──────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 2006); ─────────────────────────────────╮</span>
+<span class="r23">│</span> <span class="r1">&lt;</span><span class="r24">rst-document</span><span class="r1">&gt;</span>:<span class="r23">2006</span>: <span class="r1">(</span>INFO/<span class="r23">1</span><span class="r1">)</span> Duplicate implicit target name: <span class="r25">&quot;figure&quot;</span>.                                              <span class="r23">│</span>
+<span class="r23">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r23">╭──────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 2010); ─────────────────────────────────╮</span>
+<span class="r23">│</span> <span class="r1">&lt;</span><span class="r24">rst-document</span><span class="r1">&gt;</span>:<span class="r23">2010</span>: <span class="r1">(</span>INFO/<span class="r23">1</span><span class="r1">)</span> Duplicate implicit target name: <span class="r25">&quot;image&quot;</span>.                                               <span class="r23">│</span>
+<span class="r23">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r23">╭──────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 2022); ─────────────────────────────────╮</span>
+<span class="r23">│</span> <span class="r1">&lt;</span><span class="r24">rst-document</span><span class="r1">&gt;</span>:<span class="r23">2022</span>: <span class="r1">(</span>INFO/<span class="r23">1</span><span class="r1">)</span> Duplicate implicit target name: <span class="r25">&quot;rubric&quot;</span>.                                              <span class="r23">│</span>
+<span class="r23">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r23">╭──────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 2023); ─────────────────────────────────╮</span>
+<span class="r23">│</span> <span class="r1">&lt;</span><span class="r24">rst-document</span><span class="r1">&gt;</span>:<span class="r23">2023</span>: <span class="r1">(</span>INFO/<span class="r23">1</span><span class="r1">)</span> Duplicate implicit target name: <span class="r25">&quot;sidebar&quot;</span>.                                             <span class="r23">│</span>
+<span class="r23">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r23">╭──────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 2024); ─────────────────────────────────╮</span>
+<span class="r23">│</span> <span class="r1">&lt;</span><span class="r24">rst-document</span><span class="r1">&gt;</span>:<span class="r23">2024</span>: <span class="r1">(</span>INFO/<span class="r23">1</span><span class="r1">)</span> Duplicate implicit target name: <span class="r25">&quot;table&quot;</span>.                                               <span class="r23">│</span>
+<span class="r23">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r23">╭──────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 2027); ─────────────────────────────────╮</span>
+<span class="r23">│</span> <span class="r1">&lt;</span><span class="r24">rst-document</span><span class="r1">&gt;</span>:<span class="r23">2027</span>: <span class="r1">(</span>INFO/<span class="r23">1</span><span class="r1">)</span> Duplicate implicit target name: <span class="r25">&quot;topic&quot;</span>.                                               <span class="r23">│</span>
+<span class="r23">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r26">┌─────────────────────────────────────────────────────── Footer ───────────────────────────────────────────────────────┐</span>
+<span class="r26">│</span>                            &quot;Metadata&quot; is data about data, in this case data about the                                <span class="r26">│</span>
+<span class="r26">│</span>                            document. Metadata is, e.g., used to describe and classify web                            <span class="r26">│</span>
+<span class="r26">│</span>                            pages in the World Wide Web, in a form that is easy for search                            <span class="r26">│</span>
+<span class="r26">│</span>                            engines to extract and collate.                                                           <span class="r26">│</span>
+<span class="r26">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+</code></pre>
+</body>
+</html>

--- a/tests/test_vectors/introduction.rst
+++ b/tests/test_vectors/introduction.rst
@@ -1,0 +1,311 @@
+=====================================
+ An Introduction to reStructuredText
+=====================================
+:Author: David Goodger
+:Contact: docutils-develop@lists.sourceforge.net
+:Revision: $Revision: 8959 $
+:Date: $Date: 2022-01-21 14:45:42 +0100 (Fr, 21. JÃ¤n 2022) $
+:Copyright: This document has been placed in the public domain.
+
+reStructuredText_ is an easy-to-read, what-you-see-is-what-you-get
+plaintext markup syntax and parser system.  It is useful for inline
+program documentation (such as Python docstrings), for quickly
+creating simple web pages, and for standalone documents.
+reStructuredText_ is a proposed revision and reinterpretation of the
+StructuredText_ and Setext_ lightweight markup systems.
+
+reStructuredText is designed for extensibility for specific
+application domains.  Its parser is a component of Docutils_.
+
+This document defines the goals_ of reStructuredText and provides a
+history_ of the project.  It is written using the reStructuredText
+markup, and therefore serves as an example of its use.  For a gentle
+introduction to using reStructuredText, please read `A
+ReStructuredText Primer`_.  The `Quick reStructuredText`_ user
+reference is also useful.  The `reStructuredText Markup
+Specification`_ is the definitive reference.  There is also an
+analysis of the `Problems With StructuredText`_.
+
+ReStructuredText's web page is
+https://docutils.sourceforge.io/rst.html.
+
+.. _reStructuredText: https://docutils.sourceforge.io/rst.html
+.. _StructuredText: https://zopestructuredtext.readthedocs.org/
+.. _Setext: https://docutils.sourceforge.io/mirror/setext.html
+.. _Docutils: https://docutils.sourceforge.io/
+.. _A ReStructuredText Primer: ../../user/rst/quickstart.html
+.. _Quick reStructuredText: ../../user/rst/quickref.html
+.. _reStructuredText Markup Specification: restructuredtext.html
+.. _Problems with StructuredText: ../../dev/rst/problems.html
+
+
+Goals
+=====
+
+The primary goal of reStructuredText_ is to define a markup syntax for
+use in Python docstrings and other documentation domains, that is
+readable and simple, yet powerful enough for non-trivial use.  The
+intended purpose of the reStructuredText markup is twofold:
+
+- the establishment of a set of standard conventions allowing the
+  expression of structure within plaintext, and
+
+- the conversion of such documents into useful structured data
+  formats.
+
+The secondary goal of reStructuredText is to be accepted by the Python
+community (by way of being blessed by PythonLabs and the BDFL [#]_) as
+a standard for Python inline documentation (possibly one of several
+standards, to account for taste).
+
+.. [#] Python's creator and "Benevolent Dictator For Life",
+   Guido van Rossum.
+
+To clarify the primary goal, here are specific design goals, in order,
+beginning with the most important:
+
+1. Readable.  The marked-up text must be easy to read without any
+   prior knowledge of the markup language.  It should be as easily
+   read in raw form as in processed form.
+
+2. Unobtrusive.  The markup that is used should be as simple and
+   unobtrusive as possible.  The simplicity of markup constructs
+   should be roughly proportional to their frequency of use.  The most
+   common constructs, with natural and obvious markup, should be the
+   simplest and most unobtrusive.  Less common constructs, for which
+   there is no natural or obvious markup, should be distinctive.
+
+3. Unambiguous.  The rules for markup must not be open for
+   interpretation.  For any given input, there should be one and only
+   one possible output (including error output).
+
+4. Unsurprising.  Markup constructs should not cause unexpected output
+   upon processing.  As a fallback, there must be a way to prevent
+   unwanted markup processing when a markup construct is used in a
+   non-markup context (for example, when documenting the markup syntax
+   itself).
+
+5. Intuitive.  Markup should be as obvious and easily remembered as
+   possible, for the author as well as for the reader.  Constructs
+   should take their cues from such naturally occurring sources as
+   plaintext email messages, newsgroup postings, and text
+   documentation such as README.txt files.
+
+6. Easy.  It should be easy to mark up text using any ordinary text
+   editor.
+
+7. Scalable.  The markup should be applicable regardless of the length
+   of the text.
+
+8. Powerful.  The markup should provide enough constructs to produce a
+   reasonably rich structured document.
+
+9. Language-neutral.  The markup should apply to multiple natural (as
+   well as artificial) languages, not only English.
+
+10. Extensible.  The markup should provide a simple syntax and
+    interface for adding more complex general markup, and custom
+    markup.
+
+11. Output-format-neutral.  The markup will be appropriate for
+    processing to multiple output formats, and will not be biased
+    toward any particular format.
+
+The design goals above were used as criteria for accepting or
+rejecting syntax, or selecting between alternatives.
+
+It is emphatically *not* the goal of reStructuredText to define
+docstring semantics, such as docstring contents or docstring length.
+These issues are orthogonal to the markup syntax and beyond the scope
+of this specification.
+
+Also, it is not the goal of reStructuredText to maintain compatibility
+with StructuredText_ or Setext_.  reStructuredText shamelessly steals
+their great ideas and ignores the not-so-great.
+
+Author's note:
+
+    Due to the nature of the problem we're trying to solve (or,
+    perhaps, due to the nature of the proposed solution), the above
+    goals unavoidably conflict.  I have tried to extract and distill
+    the wisdom accumulated over the years in the Python Doc-SIG_
+    mailing list and elsewhere, to come up with a coherent and
+    consistent set of syntax rules, and the above goals by which to
+    measure them.
+
+    There will inevitably be people who disagree with my particular
+    choices.  Some desire finer control over their markup, others
+    prefer less.  Some are concerned with very short docstrings,
+    others with full-length documents.  This specification is an
+    effort to provide a reasonably rich set of markup constructs in a
+    reasonably simple form, that should satisfy a reasonably large
+    group of reasonable people.
+
+    David Goodger (goodger@python.org), 2001-04-20
+
+.. _Doc-SIG: https://www.python.org/sigs/doc-sig/
+
+
+History
+=======
+
+reStructuredText_, the specification, is based on StructuredText_ and
+Setext_.  StructuredText was developed by Jim Fulton of `Zope
+Corporation`_ (formerly Digital Creations) and first released in 1996.
+It is now released as a part of the open-source "Z Object Publishing
+Environment" (ZOPE_).  Ian Feldman's and Tony Sanders' earlier Setext_
+specification was either an influence on StructuredText or, by their
+similarities, at least evidence of the correctness of this approach.
+
+I discovered StructuredText_ in late 1999 while searching for a way to
+document the Python modules in one of my projects.  Version 1.1 of
+StructuredText was included in Daniel Larsson's pythondoc_.  Although
+I was not able to get pythondoc to work for me, I found StructuredText
+to be almost ideal for my needs.  I joined the Python Doc-SIG_
+(Documentation Special Interest Group) mailing list and found an
+ongoing discussion of the shortcomings of the StructuredText
+"standard".  This discussion has been going on since the inception of
+the mailing list in 1996, and possibly predates it.
+
+I decided to modify the original module with my own extensions and
+some suggested by the Doc-SIG members.  I soon realized that the
+module was not written with extension in mind, so I embarked upon a
+general reworking, including adapting it to the "re" regular
+expression module (the original inspiration for the name of this
+project).  Soon after I completed the modifications, I discovered that
+StructuredText.py was up to version 1.23 in the ZOPE distribution.
+Implementing the new syntax extensions from version 1.23 proved to be
+an exercise in frustration, as the complexity of the module had become
+overwhelming.
+
+In 2000, development on StructuredTextNG ("Next Generation") began at
+`Zope Corporation`_ (then Digital Creations).  It seems to have many
+improvements, but still suffers from many of the problems of classic
+StructuredText.
+
+I decided that a complete rewrite was in order, and even started a
+`reStructuredText SourceForge project`_ (now inactive).  My
+motivations (the "itches" I aim to "scratch") are as follows:
+
+- I need a standard format for inline documentation of the programs I
+  write.  This inline documentation has to be convertible to other
+  useful formats, such as HTML.  I believe many others have the same
+  need.
+
+- I believe in the Setext/StructuredText idea and want to help
+  formalize the standard.  However, I feel the current specifications
+  and implementations have flaws that desperately need fixing.
+
+- reStructuredText could form part of the foundation for a
+  documentation extraction and processing system, greatly benefitting
+  Python.  But it is only a part, not the whole.  reStructuredText is
+  a markup language specification and a reference parser
+  implementation, but it does not aspire to be the entire system.  I
+  don't want reStructuredText or a hypothetical Python documentation
+  processor to die stillborn because of over-ambition.
+
+- Most of all, I want to help ease the documentation chore, the bane
+  of many a programmer.
+
+Unfortunately I was sidetracked and stopped working on this project.
+In November 2000 I made the time to enumerate the problems of
+StructuredText and possible solutions, and complete the first draft of
+a specification.  This first draft was posted to the Doc-SIG in three
+parts:
+
+- `A Plan for Structured Text`__
+- `Problems With StructuredText`__
+- `reStructuredText: Revised Structured Text Specification`__
+
+__ https://mail.python.org/pipermail/doc-sig/2000-November/001239.html
+__ https://mail.python.org/pipermail/doc-sig/2000-November/001240.html
+__ https://mail.python.org/pipermail/doc-sig/2000-November/001241.html
+
+In March 2001 a flurry of activity on the Doc-SIG spurred me to
+further revise and refine my specification, the result of which you
+are now reading.  An offshoot of the reStructuredText project has been
+the realization that a single markup scheme, no matter how well
+thought out, may not be enough.  In order to tame the endless debates
+on Doc-SIG, a flexible `Docstring Processing System framework`_ needed
+to be constructed.  This framework has become the more important of
+the two projects; reStructuredText_ has found its place as one
+possible choice for a single component of the larger framework.
+
+The project web site and the first project release were rolled out in
+June 2001, including posting the second draft of the spec [#spec-2]_
+and the first draft of PEPs 256, 257, and 258 [#peps-1]_ to the
+Doc-SIG.  These documents and the project implementation proceeded to
+evolve at a rapid pace.  Implementation history details can be found
+in the `project history file`_.
+
+In November 2001, the reStructuredText parser was nearing completion.
+Development of the parser continued with the addition of small
+convenience features, improvements to the syntax, the filling in of
+gaps, and bug fixes.  After a long holiday break, in early 2002 most
+development moved over to the other Docutils components, the
+"Readers", "Writers", and "Transforms".  A "standalone" reader
+(processes standalone text file documents) was completed in February,
+and a basic HTML writer (producing HTML 4.01, using CSS-1) was
+completed in early March.
+
+`PEP 287`_, "reStructuredText Standard Docstring Format", was created
+to formally propose reStructuredText as a standard format for Python
+docstrings, PEPs, and other files.  It was first posted to
+comp.lang.python_ and the Python-dev_ mailing list on 2002-04-02.
+
+Version 0.4 of the reStructuredText__ and `Docstring Processing
+System`_ projects were released in April 2002.  The two projects were
+immediately merged, renamed to "Docutils_", and a 0.1 release soon
+followed.
+
+.. __: `reStructuredText SourceForge project`_
+
+.. [#spec-2] The second draft of the spec:
+
+   - `An Introduction to reStructuredText`__
+   - `Problems With StructuredText`__
+   - `reStructuredText Markup Specification`__
+   - `Python Extensions to the reStructuredText Markup
+     Specification`__
+
+   __ https://mail.python.org/pipermail/doc-sig/2001-June/001858.html
+   __ https://mail.python.org/pipermail/doc-sig/2001-June/001859.html
+   __ https://mail.python.org/pipermail/doc-sig/2001-June/001860.html
+   __ https://mail.python.org/pipermail/doc-sig/2001-June/001861.html
+
+.. [#peps-1] First drafts of the PEPs:
+
+   - `PEP 256: Docstring Processing System Framework`__
+   - `PEP 258: DPS Generic Implementation Details`__
+   - `PEP 257: Docstring Conventions`__
+
+   Current working versions of the PEPs can be found in
+   https://docutils.sourceforge.io/docs/peps/, and official versions
+   can be found in the `master PEP repository`_.
+
+   __ https://mail.python.org/pipermail/doc-sig/2001-June/001855.html
+   __ https://mail.python.org/pipermail/doc-sig/2001-June/001856.html
+   __ https://mail.python.org/pipermail/doc-sig/2001-June/001857.html
+
+
+.. _Zope Corporation: http://www.zope.com
+.. _ZOPE: https://www.zope.dev
+.. _reStructuredText SourceForge project:
+   http://structuredtext.sourceforge.net/
+.. _pythondoc: http://starship.python.net/crew/danilo/pythondoc/
+.. _project history file: ../../../HISTORY.html
+.. _PEP 287: ../../peps/pep-0287.html
+.. _Docstring Processing System framework: ../../peps/pep-0256.html
+.. _comp.lang.python: news:comp.lang.python
+.. _Python-dev: https://mail.python.org/pipermail/python-dev/
+.. _Docstring Processing System: http://docstring.sourceforge.net/
+.. _master PEP repository: https://www.python.org/dev/peps/
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   End:

--- a/tests/test_vectors/introduction_expected.html
+++ b/tests/test_vectors/introduction_expected.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+.r1 {font-weight: bold}
+.r2 {color: #bd93f9; text-decoration-color: #bd93f9; background-color: #282a36; text-decoration: underline}
+.r3 {color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #282a36}
+.r4 {color: #f1fa8c; text-decoration-color: #f1fa8c; font-weight: bold}
+.r5 {font-style: italic}
+.r6 {color: #ffffff; text-decoration-color: #ffffff}
+.r7 {color: #bcbcbc; text-decoration-color: #bcbcbc}
+body {
+    color: #f8f8f2;
+    background-color: #282a36;
+}
+</style>
+</head>
+<body>
+    <pre style="font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace"><code style="font-family:inherit"><span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                         An Introduction to reStructuredText                                          ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name </span>┃<span class="r1"> Field Value                                            </span>┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Author    </span> │ David Goodger                                          │
+├────────────┼────────────────────────────────────────────────────────┤
+│ <span class="r1">Contact   </span> │ docutils-develop@lists.sourceforge.net                 │
+├────────────┼────────────────────────────────────────────────────────┤
+│ <span class="r1">Revision  </span> │ $Revision: 8959 $                                      │
+├────────────┼────────────────────────────────────────────────────────┤
+│ <span class="r1">Date      </span> │ $Date: 2022-01-21 14:45:42 +0100 (Fr, 21. JÃ¤n 2022) $ │
+├────────────┼────────────────────────────────────────────────────────┤
+│ <span class="r1">Copyright </span> │ This document has been placed in the public domain.    │
+└────────────┴────────────────────────────────────────────────────────┘
+<span class="r2">reStructuredText</span><span class="r3"> is an easy-to-read, what-you-see-is-what-you-get plaintext markup syntax and parser system.  It is </span>
+<span class="r3">useful for inline program documentation (such as Python docstrings), for quickly creating simple web pages, and for </span>
+<span class="r3">standalone documents. </span><a class="r2" href="https://docutils.sourceforge.io/rst.html">reStructuredText</a><span class="r3"> is a proposed revision and reinterpretation of the </span><a class="r2" href="https://zopestructuredtext.readthedocs.org/">StructuredText</a><span class="r3"> and </span><a class="r2" href="https://docutils.sourceforge.io/mirror/setext.html">Setext</a><span class="r3"> </span>
+<span class="r3">lightweight markup systems.</span>
+
+<span class="r3">reStructuredText is designed for extensibility for specific application domains.  Its parser is a component of </span><a class="r2" href="https://docutils.sourceforge.io/">Docutils</a><span class="r3">.</span>
+
+<span class="r3">This document defines the </span><span class="r2">goals</span><span class="r3"> of reStructuredText and provides a </span><span class="r2">history</span><span class="r3"> of the project.  It is written using the </span>
+<span class="r3">reStructuredText markup, and therefore serves as an example of its use.  For a gentle introduction to using </span>
+<span class="r3">reStructuredText, please read </span><a class="r2" href="../../user/rst/quickstart.html">A ReStructuredText Primer</a><span class="r3">.  The </span><a class="r2" href="../../user/rst/quickref.html">Quick reStructuredText</a><span class="r3"> user reference is also useful.  The</span>
+<a class="r2" href="restructuredtext.html">reStructuredText Markup Specification</a><span class="r3"> is the definitive reference.  There is also an analysis of the </span><a class="r2" href="../../dev/rst/problems.html">Problems With </a>
+<a class="r2" href="../../dev/rst/problems.html">StructuredText</a><span class="r3">.</span>
+
+<span class="r3">ReStructuredText&#x27;s web page is </span><a class="r2" href="https://docutils.sourceforge.io/rst.html">https://docutils.sourceforge.io/rst.html</a><span class="r3">.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                        Goals                                                         ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r3">The primary goal of </span><span class="r2">reStructuredText</span><span class="r3"> is to define a markup syntax for use in Python docstrings and other documentation </span>
+<span class="r3">domains, that is readable and simple, yet powerful enough for non-trivial use.  The intended purpose of the </span>
+<span class="r3">reStructuredText markup is twofold:</span>
+
+<span class="r4"> • </span>the establishment of a set of standard conventions allowing the expression of structure within plaintext, and
+<span class="r4"> • </span>the conversion of such documents into useful structured data formats.
+<span class="r3">The secondary goal of reStructuredText is to be accepted by the Python community (by way of being blessed by PythonLabs </span>
+<span class="r3">and the BDFL ) as a standard for Python inline documentation (possibly one of several standards, to account for </span>
+<span class="r3">taste).To clarify the primary goal, here are specific design goals, in order, beginning with the most important:</span>
+<span class="r4"> 1</span> Readable.  The marked-up text must be easy to read without any prior knowledge of the markup language.  It should be 
+easily read in raw form as in processed form.
+<span class="r4"> 2</span> Unobtrusive.  The markup that is used should be as simple and unobtrusive as possible.  The simplicity of markup 
+constructs should be roughly proportional to their frequency of use.  The most common constructs, with natural and 
+obvious markup, should be the simplest and most unobtrusive.  Less common constructs, for which there is no natural or 
+obvious markup, should be distinctive.
+<span class="r4"> 3</span> Unambiguous.  The rules for markup must not be open for interpretation.  For any given input, there should be one and
+only one possible output (including error output).
+<span class="r4"> 4</span> Unsurprising.  Markup constructs should not cause unexpected output upon processing.  As a fallback, there must be a 
+to prevent unwanted markup processing when a markup construct is used in a non-markup context (for example, when 
+documenting the markup syntax itself).
+<span class="r4"> 5</span> Intuitive.  Markup should be as obvious and easily remembered as possible, for the author as well as for the reader. 
+Constructs should take their cues from such naturally occurring sources as plaintext email messages, newsgroup postings,
+and text documentation such as README.txt files.
+<span class="r4"> 6</span> Easy.  It should be easy to mark up text using any ordinary text editor.
+<span class="r4"> 7</span> Scalable.  The markup should be applicable regardless of the length of the text.
+<span class="r4"> 8</span> Powerful.  The markup should provide enough constructs to produce a reasonably rich structured document.
+<span class="r4"> 9</span> Language-neutral.  The markup should apply to multiple natural (as well as artificial) languages, not only English.
+<span class="r4"> 10</span> Extensible.  The markup should provide a simple syntax and interface for adding more complex general markup, and cus
+markup.
+<span class="r4"> 11</span> Output-format-neutral.  The markup will be appropriate for processing to multiple output formats, and will not be bi
+toward any particular format.
+<span class="r3">The design goals above were used as criteria for accepting or rejecting syntax, or selecting between alternatives.It is </span>
+<span class="r3">emphatically </span><span class="r5">not</span><span class="r3"> the goal of reStructuredText to define docstring semantics, such as docstring contents or docstring </span>
+<span class="r3">length. These issues are orthogonal to the markup syntax and beyond the scope of this specification.Also, it is not the </span>
+<span class="r3">goal of reStructuredText to maintain compatibility with </span><span class="r2">StructuredText</span><span class="r3"> or </span><span class="r2">Setext</span><span class="r3">.  reStructuredText shamelessly steals </span>
+<span class="r3">their great ideas and ignores the not-so-great.Author&#x27;s note:</span>
+    <span class="r6">Due to the nature of the problem we&#x27;re trying to solve (or, perhaps, due to the nature of the proposed solution), </span>
+<span class="r6">the above goals unavoidably conflict.  I have tried to extract and distill the wisdom accumulated over the years in the </span>
+<span class="r6">Python Doc-SIG mailing list and elsewhere, to come up with a coherent and consistent set of syntax rules, and the above </span>
+<span class="r6">goals by which to measure them.</span>
+
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                       History                                                        ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r2">reStructuredText</span><span class="r3">, the specification, is based on </span><span class="r2">StructuredText</span><span class="r3"> and </span><span class="r2">Setext</span><span class="r3">.  StructuredText was developed by Jim Fulton </span>
+<span class="r3">of </span><span class="r2">Zope Corporation</span><span class="r3"> (formerly Digital Creations) and first released in 1996. It is now released as a part of the </span>
+<span class="r3">open-source &quot;Z Object Publishing Environment&quot; (</span><a class="r2" href="https://www.zope.dev">ZOPE</a><span class="r3">).  Ian Feldman&#x27;s and Tony Sanders&#x27; earlier </span><span class="r2">Setext</span><span class="r3"> specification was </span>
+<span class="r3">either an influence on StructuredText or, by their similarities, at least evidence of the correctness of this approach.</span>
+
+<span class="r3">I discovered </span><span class="r2">StructuredText</span><span class="r3"> in late 1999 while searching for a way to document the Python modules in one of my projects.</span>
+<span class="r3">Version 1.1 of StructuredText was included in Daniel Larsson&#x27;s </span><a class="r2" href="http://starship.python.net/crew/danilo/pythondoc/">pythondoc</a><span class="r3">.  Although I was not able to get pythondoc to </span>
+<span class="r3">work for me, I found StructuredText to be almost ideal for my needs.  I joined the Python </span><span class="r2">Doc-SIG</span><span class="r3"> (Documentation Special</span>
+<span class="r3">Interest Group) mailing list and found an ongoing discussion of the shortcomings of the StructuredText &quot;standard&quot;.  This</span>
+<span class="r3">discussion has been going on since the inception of the mailing list in 1996, and possibly predates it.</span>
+
+<span class="r3">I decided to modify the original module with my own extensions and some suggested by the Doc-SIG members.  I soon </span>
+<span class="r3">realized that the module was not written with extension in mind, so I embarked upon a general reworking, including </span>
+<span class="r3">adapting it to the &quot;re&quot; regular expression module (the original inspiration for the name of this project).  Soon after I</span>
+<span class="r3">completed the modifications, I discovered that StructuredText.py was up to version 1.23 in the ZOPE distribution. </span>
+<span class="r3">Implementing the new syntax extensions from version 1.23 proved to be an exercise in frustration, as the complexity of </span>
+<span class="r3">the module had become overwhelming.</span>
+
+<span class="r3">In 2000, development on StructuredTextNG (&quot;Next Generation&quot;) began at </span><a class="r2" href="http://www.zope.com">Zope Corporation</a><span class="r3"> (then Digital Creations).  It </span>
+<span class="r3">seems to have many improvements, but still suffers from many of the problems of classic StructuredText.</span>
+
+<span class="r3">I decided that a complete rewrite was in order, and even started a </span><a class="r2" href="http://structuredtext.sourceforge.net/">reStructuredText SourceForge project</a><span class="r3"> (now inactive). </span>
+<span class="r3">My motivations (the &quot;itches&quot; I aim to &quot;scratch&quot;) are as follows:</span>
+
+<span class="r4"> • </span>I need a standard format for inline documentation of the programs I write.  This inline documentation has to be 
+convertible to other useful formats, such as HTML.  I believe many others have the same need.
+<span class="r4"> • </span>I believe in the Setext/StructuredText idea and want to help formalize the standard.  However, I feel the current 
+specifications and implementations have flaws that desperately need fixing.
+<span class="r4"> • </span>reStructuredText could form part of the foundation for a documentation extraction and processing system, greatly 
+benefitting Python.  But it is only a part, not the whole.  reStructuredText is a markup language specification and a 
+reference parser implementation, but it does not aspire to be the entire system.  I don&#x27;t want reStructuredText or a 
+hypothetical Python documentation processor to die stillborn because of over-ambition.
+<span class="r4"> • </span>Most of all, I want to help ease the documentation chore, the bane of many a programmer.
+<span class="r3">Unfortunately I was sidetracked and stopped working on this project. In November 2000 I made the time to enumerate the </span>
+<span class="r3">problems of StructuredText and possible solutions, and complete the first draft of a specification.  This first draft </span>
+<span class="r3">was posted to the Doc-SIG in three parts:</span>
+<span class="r4"> • </span>A Plan for Structured Text
+<span class="r4"> • </span>Problems With StructuredText
+<span class="r4"> • </span>reStructuredText: Revised Structured Text Specification
+<span class="r3">In March 2001 a flurry of activity on the Doc-SIG spurred me to further revise and refine my specification, the result </span>
+<span class="r3">of which you are now reading.  An offshoot of the reStructuredText project has been the realization that a single markup</span>
+<span class="r3">scheme, no matter how well thought out, may not be enough.  In order to tame the endless debates on Doc-SIG, a flexible </span>
+<a class="r2" href="../../peps/pep-0256.html">Docstring Processing System framework</a><span class="r3"> needed to be constructed.  This framework has become the more important of the two</span>
+<span class="r3">projects; </span><span class="r2">reStructuredText</span><span class="r3"> has found its place as one possible choice for a single component of the larger framework.The</span>
+<span class="r3">project web site and the first project release were rolled out in June 2001, including posting the second draft of the </span>
+<span class="r3">spec  and the first draft of PEPs 256, 257, and 258  to the Doc-SIG.  These documents and the project implementation </span>
+<span class="r3">proceeded to evolve at a rapid pace.  Implementation history details can be found in the </span><a class="r2" href="../../../HISTORY.html">project history file</a><span class="r3">.In </span>
+<span class="r3">November 2001, the reStructuredText parser was nearing completion. Development of the parser continued with the addition</span>
+<span class="r3">of small convenience features, improvements to the syntax, the filling in of gaps, and bug fixes.  After a long holiday </span>
+<span class="r3">break, in early 2002 most development moved over to the other Docutils components, the &quot;Readers&quot;, &quot;Writers&quot;, and </span>
+<span class="r3">&quot;Transforms&quot;.  A &quot;standalone&quot; reader (processes standalone text file documents) was completed in February, and a basic </span>
+<span class="r3">HTML writer (producing HTML 4.01, using CSS-1) was completed in early March.</span><a class="r2" href="../../peps/pep-0287.html">PEP 287</a><span class="r3">, &quot;reStructuredText Standard </span>
+<span class="r3">Docstring Format&quot;, was created to formally propose reStructuredText as a standard format for Python docstrings, PEPs, </span>
+<span class="r3">and other files.  It was first posted to </span><a class="r2" href="news:comp.lang.python">comp.lang.python</a><span class="r3"> and the </span><a class="r2" href="https://mail.python.org/pipermail/python-dev/">Python-dev</a><span class="r3"> mailing list on 2002-04-02.Version 0.4 of </span>
+<span class="r3">the </span><span class="r2">reStructuredText</span><span class="r3"> and </span><a class="r2" href="http://docstring.sourceforge.net/">Docstring Processing System</a><span class="r3"> projects were released in April 2002.  The two projects were </span>
+<span class="r3">immediately merged, renamed to &quot;</span><span class="r2">Docutils</span><span class="r3">&quot;, and a 0.1 release soon followed.</span>
+<span class="r7">┌─────────────────────────────────────────────────────── Footer ───────────────────────────────────────────────────────┐</span>
+<span class="r7">│</span>                          First drafts of the PEPs:                                                                   <span class="r7">│</span>
+<span class="r7">│</span>                                                                                                                      <span class="r7">│</span>
+<span class="r7">│</span>                          PEP 256: Docstring Processing System Framework                                              <span class="r7">│</span>
+<span class="r7">│</span>                                                                                                                      <span class="r7">│</span>
+<span class="r7">│</span>                          PEP 258: DPS Generic Implementation Details                                                 <span class="r7">│</span>
+<span class="r7">│</span>                                                                                                                      <span class="r7">│</span>
+<span class="r7">│</span>                          PEP 257: Docstring Conventions                                                              <span class="r7">│</span>
+<span class="r7">│</span>                                                                                                                      <span class="r7">│</span>
+<span class="r7">│</span>                          Current working versions of the PEPs can be found in                                        <span class="r7">│</span>
+<span class="r7">│</span>                          https://docutils.sourceforge.io/docs/peps/, and official versions                           <span class="r7">│</span>
+<span class="r7">│</span>                          can be found in the master PEP repository.                                                  <span class="r7">│</span>
+<span class="r7">│</span>                                                                                                                      <span class="r7">│</span>
+<span class="r7">│</span>                                                                                                                      <span class="r7">│</span>
+<span class="r7">│</span>                                                                                                                      <span class="r7">│</span>
+<span class="r7">│</span>                                                                                                                      <span class="r7">│</span>
+<span class="r7">│</span>                                                                                                                      <span class="r7">│</span>
+<span class="r7">│</span>                                                                                                                      <span class="r7">│</span>
+<span class="r7">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+</code></pre>
+</body>
+</html>

--- a/tests/test_vectors/paragraph_basic.rst
+++ b/tests/test_vectors/paragraph_basic.rst
@@ -1,0 +1,4 @@
+A paragraph must be
+left-aligned.
+
+This is a different paragraph.

--- a/tests/test_vectors/paragraph_basic_expected.html
+++ b/tests/test_vectors/paragraph_basic_expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+.r1 {color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #282a36}
+body {
+    color: #f8f8f2;
+    background-color: #282a36;
+}
+</style>
+</head>
+<body>
+    <pre style="font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace"><code style="font-family:inherit"><span class="r1">A paragraph must be left-aligned.</span>
+
+<span class="r1">This is a different paragraph.</span>
+
+</code></pre>
+</body>
+</html>

--- a/tests/test_vectors/paragraph_basic_expected.html
+++ b/tests/test_vectors/paragraph_basic_expected.html
@@ -14,7 +14,6 @@ body {
     <pre style="font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace"><code style="font-family:inherit"><span class="r1">A paragraph must be left-aligned.</span>
 
 <span class="r1">This is a different paragraph.</span>
-
 </code></pre>
 </body>
 </html>

--- a/tests/test_vectors/rich_introduction.rst
+++ b/tests/test_vectors/rich_introduction.rst
@@ -1,0 +1,106 @@
+Introduction
+============
+
+Rich is a Python library for writing *rich* text (with color and style) to the terminal, and for displaying advanced content such as tables, markdown, and syntax highlighted code. 
+
+Use Rich to make your command line applications visually appealing and present data in a more readable way. Rich can also be a useful debugging aid by pretty printing and syntax highlighting data structures.
+
+Requirements
+------------
+
+Rich works with OSX, Linux and Windows.
+
+On Windows both the (ancient) cmd.exe terminal is supported and the new `Windows Terminal <https://github.com/microsoft/terminal/releases>`_. The latter has much improved support for color and style.
+
+Rich requires Python 3.6.1 and above. Note that Python 3.6.0 is *not* supported due to lack of support for methods on NamedTuples.
+
+.. note::
+    PyCharm users will need to enable "emulate terminal" in output console option in run/debug configuration to see styled output.
+
+Installation
+------------
+
+You can install Rich from PyPI with `pip` or your favorite package manager::
+
+    pip install rich
+
+Add the ``-U`` switch to update to the current version, if Rich is already installed.
+
+If you intend to use Rich with Jupyter then there are some additional dependencies which you can install with the following command::
+
+    pip install rich[jupyter]
+
+
+Quick Start
+-----------
+
+The quickest way to get up and running with Rich is to import the alternative ``print`` function which takes the same arguments as the built-in ``print`` and may be used as a drop-in replacement. Here's how you would do that::
+
+    from rich import print
+
+You can then print strings or objects to the terminal in the usual way. Rich will do some basic syntax highlighting and format data structures to make them easier to read.
+
+Strings may contain :ref:`console_markup` which can be used to insert color and styles in to the output.
+
+The following demonstrates both console markup and pretty formatting of Python objects::
+
+    >>> print("[italic red]Hello[/italic red] World!", locals())
+
+This writes the following output to the terminal (including all the colors and styles):
+
+.. raw:: html
+
+    <pre style="font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace"><span style="color: #800000; font-style: italic">Hello</span> World!                                                 
+    <span style="font-weight: bold">{</span>
+        <span style="color: #008000">'__annotations__'</span>: <span style="font-weight: bold">{}</span>,
+        <span style="color: #008000">'__builtins__'</span>: <span style="font-weight: bold"><</span><span style="color: #ff00ff">module</span><span style="color: #000000"> </span><span style="color: #008000">'builtins'</span><span style="color: #000000"> </span><span style="color: #000000; font-weight: bold">(</span><span style="color: #000000">built-in</span><span style="color: #000000; font-weight: bold">)</span><span style="font-weight: bold">></span>,
+        <span style="color: #008000">'__doc__'</span>: <span style="color: #800080; font-style: italic">None</span>,
+        <span style="color: #008000">'__loader__'</span>: <span style="font-weight: bold"><</span><span style="color: #ff00ff">class</span><span style="color: #000000"> </span><span style="color: #008000">'_frozen_importlib.BuiltinImporter'</span><span style="font-weight: bold">></span>,
+        <span style="color: #008000">'__name__'</span>: <span style="color: #008000">'__main__'</span>,
+        <span style="color: #008000">'__package__'</span>: <span style="color: #800080; font-style: italic">None</span>,
+        <span style="color: #008000">'__spec__'</span>: <span style="color: #800080; font-style: italic">None</span>,
+        <span style="color: #008000">'print'</span>: <span style="font-weight: bold"><</span><span style="color: #ff00ff">function</span><span style="color: #000000"> print at </span><span style="color: #000080; font-weight: bold">0x1027fd4c0</span><span style="font-weight: bold">></span>,
+    <span style="font-weight: bold">}</span> </pre>
+
+
+If you would rather not shadow Python's built-in print, you can import ``rich.print`` as ``rprint`` (for example)::
+
+    from rich import print as rprint
+
+Continue reading to learn about the more advanced features of Rich.
+
+Rich in the REPL
+----------------
+
+Rich may be installed in the REPL so that Python data structures are automatically pretty printed with syntax highlighting. Here's how::
+
+    >>> from rich import pretty
+    >>> pretty.install() 
+    >>> ["Rich and pretty", True]
+
+You can also use this feature to try out Rich *renderables*. Here's an example::
+
+    >>> from rich.panel import Panel
+    >>> Panel.fit("[bold yellow]Hi, I'm a Panel", border_style="red")
+
+Read on to learn more about Rich renderables.
+
+IPython Extension
+~~~~~~~~~~~~~~~~~
+
+Rich also includes an IPython extension that will do this same pretty install + pretty tracebacks. Here's how to load it::
+
+    In [1]: %load_ext rich
+    
+You can also have it load by default by adding `"rich"` to the ``c.InteractiveShellApp.extension`` variable in 
+`IPython Configuration <https://ipython.readthedocs.io/en/stable/config/intro.html>`_.
+
+Rich Inspect
+------------
+
+Rich has an :meth:`~rich.inspect` function which can generate a report on any Python object. It is a fantastic debug aid, and a good example of the output that Rich can generate. Here is a simple example::
+
+    >>> from rich import inspect
+    >>> from rich.color import Color
+    >>> color = Color.parse("red")
+    >>> inspect(color, methods=True)

--- a/tests/test_vectors/rich_introduction_expected.html
+++ b/tests/test_vectors/rich_introduction_expected.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+.r1 {font-weight: bold}
+.r2 {color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #282a36}
+.r3 {color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #282a36; font-style: italic}
+.r4 {color: #bd93f9; text-decoration-color: #bd93f9; background-color: #282a36; text-decoration: underline}
+.r5 {color: #ffffff; text-decoration-color: #ffffff; font-weight: bold}
+.r6 {color: #949494; text-decoration-color: #949494}
+.r7 {color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822}
+.r8 {background-color: #272822}
+.r9 {color: #c6c6c6; text-decoration-color: #c6c6c6; background-color: #121212}
+.r10 {color: #ff4689; text-decoration-color: #ff4689; background-color: #272822}
+.r11 {color: #e6db74; text-decoration-color: #e6db74; background-color: #272822}
+.r12 {color: #ed007e; text-decoration-color: #ed007e; background-color: #1e0010}
+.r13 {color: #66d9ef; text-decoration-color: #66d9ef; background-color: #272822}
+.r14 {color: #a6e22e; text-decoration-color: #a6e22e; background-color: #272822}
+.r15 {color: #ae81ff; text-decoration-color: #ae81ff; background-color: #272822}
+.r16 {color: #ff5555; text-decoration-color: #ff5555; font-weight: bold}
+.r17 {color: #8be9fd; text-decoration-color: #8be9fd; font-weight: bold}
+.r18 {color: #ff79c6; text-decoration-color: #ff79c6; font-weight: bold}
+.r19 {color: #50fa7b; text-decoration-color: #50fa7b}
+body {
+    color: #f8f8f2;
+    background-color: #282a36;
+}
+</style>
+</head>
+<body>
+    <pre style="font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace"><code style="font-family:inherit"><span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     Introduction                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r2">Rich is a Python library for writing </span><span class="r3">rich</span><span class="r2"> text (with color and style) to the terminal, and for displaying advanced </span>
+<span class="r2">content such as tables, markdown, and syntax highlighted code.</span>
+
+<span class="r2">Use Rich to make your command line applications visually appealing and present data in a more readable way. Rich can </span>
+<span class="r2">also be a useful debugging aid by pretty printing and syntax highlighting data structures.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     Requirements                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r2">Rich works with OSX, Linux and Windows.</span>
+
+<span class="r2">On Windows both the (ancient) cmd.exe terminal is supported and the new </span><a class="r4" href="https://github.com/microsoft/terminal/releases">Windows Terminal</a><span class="r2">. The latter has much improved </span>
+<span class="r2">support for color and style.</span>
+
+<span class="r2">Rich requires Python 3.6.1 and above. Note that Python 3.6.0 is </span><span class="r3">not</span><span class="r2"> supported due to lack of support for methods on </span>
+<span class="r2">NamedTuples.</span>
+
+<span class="r5">╭─────────────────────────────────────────────────────── Note:  ───────────────────────────────────────────────────────╮</span>
+<span class="r5">│ PyCharm users will need to enable &quot;emulate terminal&quot; in output console option in run/debug configuration to see      │</span>
+<span class="r5">│ styled output.                                                                                                       │</span>
+<span class="r5">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     Installation                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r2">You can install Rich from PyPI with pip or your favorite package manager:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">pip install rich</span><span class="r8">                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">Add the </span><span class="r9">-U</span><span class="r2"> switch to update to the current version, if Rich is already installed.</span>
+
+<span class="r2">If you intend to use Rich with Jupyter then there are some additional dependencies which you can install with the </span>
+<span class="r2">following command:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">pip install rich[jupyter]</span><span class="r8">                                                                                           </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     Quick Start                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r2">The quickest way to get up and running with Rich is to import the alternative </span><span class="r9">print</span><span class="r2"> function which takes the same </span>
+<span class="r2">arguments as the built-in </span><span class="r9">print</span><span class="r2"> and may be used as a drop-in replacement. Here&#x27;s how you would do that:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r10">from</span><span class="r7"> rich </span><span class="r10">import</span><span class="r7"> print</span><span class="r8">                                                                                              </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">You can then print strings or objects to the terminal in the usual way. Rich will do some basic syntax highlighting and </span>
+<span class="r2">format data structures to make them easier to read.</span>
+
+<span class="r2">Strings may contain :ref:`console_markup` which can be used to insert color and styles in to the output.</span>
+
+<span class="r2">The following demonstrates both console markup and pretty formatting of Python objects:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r10">&gt;&gt;&gt;</span><span class="r7"> print(</span><span class="r11">&quot;[italic red]Hello[/italic red] World!&quot;</span><span class="r7">, locals())</span><span class="r8">                                                        </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">This writes the following output to the terminal (including all the colors and styles):</span>
+
+<span class="r6">┌─────────────────────────────────────────────── raw stripped raw html ────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">Hello World</span><span class="r12">!</span><span class="r8">                                                                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">{</span><span class="r8">                                                                                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r11">&#x27;__annotations__&#x27;</span><span class="r7">: {},</span><span class="r8">                                                                                          </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r11">&#x27;__builtins__&#x27;</span><span class="r7">: </span><span class="r10">&lt;</span><span class="r7">module </span><span class="r11">&#x27;builtins&#x27;</span><span class="r7"> (built</span><span class="r10">-in</span><span class="r7">)</span><span class="r10">&gt;</span><span class="r7">,</span><span class="r8">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r11">&#x27;__doc__&#x27;</span><span class="r7">: </span><span class="r13">None</span><span class="r7">,</span><span class="r8">                                                                                                </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r11">&#x27;__loader__&#x27;</span><span class="r7">: </span><span class="r10">&lt;</span><span class="r13">class</span><span class="r7"> </span><span class="r12">&#x27;</span><span class="r14">_frozen_importlib</span><span class="r10">.</span><span class="r7">BuiltinImporter</span><span class="r11">&#x27;&gt;,</span><span class="r8">                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r11">&#x27;__name__&#x27;</span><span class="r7">: </span><span class="r11">&#x27;__main__&#x27;</span><span class="r7">,</span><span class="r8">                                                                                         </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r11">&#x27;__package__&#x27;</span><span class="r7">: </span><span class="r13">None</span><span class="r7">,</span><span class="r8">                                                                                            </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r11">&#x27;__spec__&#x27;</span><span class="r7">: </span><span class="r13">None</span><span class="r7">,</span><span class="r8">                                                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r11">&#x27;print&#x27;</span><span class="r7">: </span><span class="r10">&lt;</span><span class="r7">function print at </span><span class="r15">0x1027fd4c0</span><span class="r10">&gt;</span><span class="r7">,</span><span class="r8">                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">} </span><span class="r8">                                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">If you would rather not shadow Python&#x27;s built-in print, you can import </span><span class="r9">rich.print</span><span class="r2"> as </span><span class="r9">rprint</span><span class="r2"> (for example):</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r10">from</span><span class="r7"> rich </span><span class="r10">import</span><span class="r7"> print </span><span class="r13">as</span><span class="r7"> rprint</span><span class="r8">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">Continue reading to learn about the more advanced features of Rich.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                   Rich in the REPL                                                   ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r2">Rich may be installed in the REPL so that Python data structures are automatically pretty printed with syntax </span>
+<span class="r2">highlighting. Here&#x27;s how:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r10">&gt;&gt;&gt;</span><span class="r7"> </span><span class="r10">from</span><span class="r7"> rich </span><span class="r10">import</span><span class="r7"> pretty</span><span class="r8">                                                                                         </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r10">&gt;&gt;&gt;</span><span class="r7"> pretty</span><span class="r10">.</span><span class="r7">install()</span><span class="r8">                                                                                                </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r10">&gt;&gt;&gt;</span><span class="r7"> [</span><span class="r11">&quot;Rich and pretty&quot;</span><span class="r7">, </span><span class="r13">True</span><span class="r7">]</span><span class="r8">                                                                                       </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">You can also use this feature to try out Rich </span><span class="r3">renderables</span><span class="r2">. Here&#x27;s an example:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r10">&gt;&gt;&gt;</span><span class="r7"> </span><span class="r10">from</span><span class="r7"> rich.panel </span><span class="r10">import</span><span class="r7"> Panel</span><span class="r8">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r10">&gt;&gt;&gt;</span><span class="r7"> Panel</span><span class="r10">.</span><span class="r7">fit(</span><span class="r11">&quot;[bold yellow]Hi, I&#x27;m a Panel&quot;</span><span class="r7">, border_style</span><span class="r10">=</span><span class="r11">&quot;red&quot;</span><span class="r7">)</span><span class="r8">                                                   </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">Read on to learn more about Rich renderables.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                  IPython Extension                                                   ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r2">Rich also includes an IPython extension that will do this same pretty install + pretty tracebacks. Here&#x27;s how to load </span>
+<span class="r2">it:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">In [</span><span class="r15">1</span><span class="r7">]: </span><span class="r10">%</span><span class="r7">load_ext rich</span><span class="r8">                                                                                              </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">You can also have it load by default by adding &quot;rich&quot; to the </span><span class="r9">c.InteractiveShellApp.extension</span><span class="r2"> variable in </span><a class="r4" href="https://ipython.readthedocs.io/en/stable/config/intro.html">IPython </a>
+<a class="r4" href="https://ipython.readthedocs.io/en/stable/config/intro.html">Configuration</a><span class="r2">.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     Rich Inspect                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r2">Rich has an :meth:`~rich.inspect` function which can generate a report on any Python object. It is a fantastic debug </span>
+<span class="r2">aid, and a good example of the output that Rich can generate. Here is a simple example:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r10">&gt;&gt;&gt;</span><span class="r7"> </span><span class="r10">from</span><span class="r7"> rich </span><span class="r10">import</span><span class="r7"> inspect</span><span class="r8">                                                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r10">&gt;&gt;&gt;</span><span class="r7"> </span><span class="r10">from</span><span class="r7"> rich.color </span><span class="r10">import</span><span class="r7"> Color</span><span class="r8">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r10">&gt;&gt;&gt;</span><span class="r7"> color </span><span class="r10">=</span><span class="r7"> Color</span><span class="r10">.</span><span class="r7">parse(</span><span class="r11">&quot;red&quot;</span><span class="r7">)</span><span class="r8">                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r10">&gt;&gt;&gt;</span><span class="r7"> inspect(color, methods</span><span class="r10">=</span><span class="r13">True</span><span class="r7">)</span><span class="r8">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r16">╭──────────────────────────────────────── System Message: Problematic Element ─────────────────────────────────────────╮</span>
+<span class="r16">│</span> <span class="r14">:ref:</span><span class="r7">`console_markup`</span><span class="r8">                                                                                               </span> <span class="r16">│</span>
+<span class="r16">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r17">╭───────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 43); ──────────────────────────────────╮</span>
+<span class="r17">│</span> <span class="r1">&lt;</span><span class="r18">rst-document</span><span class="r1">&gt;</span>:<span class="r17">43</span>: <span class="r1">(</span>INFO/<span class="r17">1</span><span class="r1">)</span> No role entry for <span class="r19">&quot;ref&quot;</span> in module <span class="r19">&quot;docutils.parsers.rst.languages.en&quot;</span>.                   <span class="r17">│</span>
+<span class="r17">│</span> Trying <span class="r19">&quot;ref&quot;</span> as canonical role name.                                                                                 <span class="r17">│</span>
+<span class="r17">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r16">╭───────────────────────────────── System Message: ERROR/3 (&lt;rst-document&gt;, line 43); ─────────────────────────────────╮</span>
+<span class="r16">│</span> <span class="r1">&lt;</span><span class="r18">rst-document</span><span class="r1">&gt;</span>:<span class="r17">43</span>: <span class="r1">(</span>ERROR/<span class="r17">3</span><span class="r1">)</span> Unknown interpreted text role <span class="r19">&quot;ref&quot;</span>.                                                    <span class="r16">│</span>
+<span class="r16">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r16">╭──────────────────────────────────────── System Message: Problematic Element ─────────────────────────────────────────╮</span>
+<span class="r16">│</span> <span class="r14">:meth:</span><span class="r7">`~rich.inspect`</span><span class="r8">                                                                                               </span> <span class="r16">│</span>
+<span class="r16">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r17">╭───────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 101); ─────────────────────────────────╮</span>
+<span class="r17">│</span> <span class="r1">&lt;</span><span class="r18">rst-document</span><span class="r1">&gt;</span>:<span class="r17">101</span>: <span class="r1">(</span>INFO/<span class="r17">1</span><span class="r1">)</span> No role entry for <span class="r19">&quot;meth&quot;</span> in module <span class="r19">&quot;docutils.parsers.rst.languages.en&quot;</span>.                 <span class="r17">│</span>
+<span class="r17">│</span> Trying <span class="r19">&quot;meth&quot;</span> as canonical role name.                                                                                <span class="r17">│</span>
+<span class="r17">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r16">╭──────────────────────────────── System Message: ERROR/3 (&lt;rst-document&gt;, line 101); ─────────────────────────────────╮</span>
+<span class="r16">│</span> <span class="r1">&lt;</span><span class="r18">rst-document</span><span class="r1">&gt;</span>:<span class="r17">101</span>: <span class="r1">(</span>ERROR/<span class="r17">3</span><span class="r1">)</span> Unknown interpreted text role <span class="r19">&quot;meth&quot;</span>.                                                  <span class="r16">│</span>
+<span class="r16">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+</code></pre>
+</body>
+</html>

--- a/tests/test_vectors/roles.rst
+++ b/tests/test_vectors/roles.rst
@@ -1,0 +1,391 @@
+=========================================
+ reStructuredText Interpreted Text Roles
+=========================================
+
+:Author: David Goodger
+:Contact: docutils-develop@lists.sourceforge.net
+:Revision: $Revision: 8959 $
+:Date: $Date: 2022-01-21 14:45:42 +0100 (Fr, 21. JÃ¤n 2022) $
+:Copyright: This document has been placed in the public domain.
+
+This document describes the interpreted text roles implemented in the
+reference reStructuredText parser.
+
+Interpreted text uses backquotes (`) around the text.  An explicit
+role marker may optionally appear before or after the text, delimited
+with colons.  For example::
+
+    This is `interpreted text` using the default role.
+
+    This is :title:`interpreted text` using an explicit role.
+
+A default role may be defined by applications of reStructuredText; it
+is used if no explicit ``:role:`` prefix or suffix is given.  The
+"default default role" is `:title-reference:`_.  It can be changed
+using the default-role_ directive.
+
+See the `Interpreted Text`_ section in the `reStructuredText Markup
+Specification`_ for syntax details.  For details on the hierarchy of
+elements, please see `The Docutils Document Tree`_ and the `Docutils
+Generic DTD`_ XML document type definition.  For interpreted text role
+implementation details, see `Creating reStructuredText Interpreted
+Text Roles`_.
+
+.. _"role" directive: directives.html#role
+.. _default-role: directives.html#default-role
+.. _Interpreted Text: restructuredtext.html#interpreted-text
+.. _reStructuredText Markup Specification: restructuredtext.html
+.. _The Docutils Document Tree: ../doctree.html
+.. _Docutils Generic DTD: ../docutils.dtd
+.. _Creating reStructuredText Interpreted Text Roles:
+   ../../howto/rst-roles.html
+
+
+.. contents::
+
+
+---------------
+ Customization
+---------------
+
+Custom interpreted text roles may be defined in a document with the
+`"role" directive`_.  Customization details are listed with each role.
+
+.. _class:
+
+A ``class`` option is recognized by the "role" directive for most
+interpreted text roles.  A description__ is provided in the `"role"
+directive`_ documentation.
+
+__ directives.html#role-class
+
+
+----------------
+ Standard Roles
+----------------
+
+``:emphasis:``
+==============
+
+:Aliases: None
+:DTD Element: emphasis
+:Customization:
+    :Options: class_.
+    :Content: None.
+
+Implements emphasis.  These are equivalent::
+
+    *text*
+    :emphasis:`text`
+
+
+``:literal:``
+==============
+
+:Aliases: None
+:DTD Element: literal
+:Customization:
+    :Options: class_.
+    :Content: None.
+
+Implements inline literal text.  These are equivalent::
+
+    ``text``
+    :literal:`text`
+
+Care must be taken with backslash-escapes though.  These are *not*
+equivalent::
+
+    ``text \ and \ backslashes``
+    :literal:`text \ and \ backslashes`
+
+The backslashes in the first line are preserved (and do nothing),
+whereas the backslashes in the second line escape the following
+spaces.
+
+
+``:code:``
+==========
+
+:Aliases: None
+:DTD Element: literal
+:Customization:
+    :Options: class_, language
+    :Content: None.
+
+(New in Docutils 0.9.)
+
+The ``code`` role marks its content as code in a formal language.
+
+For syntax highlight of inline code, the `"role" directive`_ can be used to
+build custom roles with the code language specified in the "language"
+option.
+
+For example, the following creates a LaTeX-specific "latex" role::
+
+  .. role:: latex(code)
+     :language: latex
+
+Content of the new role is parsed and tagged by the Pygments_ syntax
+highlighter. See the `code directive`_ for more info on parsing and display
+of code in reStructuredText.
+
+In addition to "class_", the following option is recognized:
+
+``language`` : text
+    Name of the code's language.
+    See `supported languages and markup formats`_ for recognized values.
+
+.. _code directive: directives.html#code
+.. _Pygments: https://pygments.org/
+.. _supported languages and markup formats: https://pygments.org/languages/
+
+
+``:math:``
+==========
+
+:Aliases: None
+:DTD Element: math
+:Customization:
+    :Options: class_
+    :Content: None.
+
+(New in Docutils 0.8.)
+
+The ``math`` role marks its content as mathematical notation (inline
+formula).
+
+The input format is LaTeX math syntax without the â€œmath delimitersâ€œ
+(``$ $``), for example::
+
+  The area of a circle is :math:`A_\text{c} = (\pi/4) d^2`.
+
+See the `math directive`_ (producing display formulas) for more info
+on mathematical notation in reStructuredText.
+
+.. _math directive: directives.html#math
+
+
+``:pep-reference:``
+===================
+
+:Aliases: ``:PEP:``
+:DTD Element: reference
+:Customization:
+    :Options: class_.
+    :Content: None.
+
+The ``:pep-reference:`` role is used to create an HTTP reference to a
+PEP (Python Enhancement Proposal).  The ``:PEP:`` alias is usually
+used.  The content must be a number, for example::
+
+    See :PEP:`287` for more information about reStructuredText.
+
+This is equivalent to::
+
+    See `PEP 287`__ for more information about reStructuredText.
+
+    __ https://www.python.org/dev/peps/pep-0287
+
+
+``:rfc-reference:``
+===================
+
+:Aliases: ``:RFC:``
+:DTD Element: reference
+:Customization:
+    :Options: class_.
+    :Content: None.
+
+The ``:rfc-reference:`` role is used to create an HTTP reference to an
+RFC (Internet Request for Comments).  The ``:RFC:`` alias is usually
+used.  The content must be a number [#]_, for example::
+
+    See :RFC:`2822` for information about email headers.
+
+This is equivalent to::
+
+    See `RFC 2822`__ for information about email headers.
+
+    __ https://tools.ietf.org/html/rfc2822.html
+
+.. [#] You can link to a specific section by saying
+   ``:rfc:`number#anchor```. (New in Docutils 0.15.)
+
+   .. Warning:: The anchor (anything following a ``#``) is appended to
+      the reference without any checks and not shown in the link text.
+
+      It is recommended to use `hyperlink references`_ for
+      anything more complex than a single RFC number.
+
+.. _hyperlink references: restructuredtext.html#hyperlink-references
+
+
+``:strong:``
+============
+
+:Aliases: None
+:DTD Element: strong
+:Customization:
+    :Options: class_.
+    :Content: None.
+
+Implements strong emphasis.  These are equivalent::
+
+    **text**
+    :strong:`text`
+
+
+``:subscript:``
+===============
+
+:Aliases: ``:sub:``
+:DTD Element: subscript
+:Customization:
+    :Options: class_.
+    :Content: None.
+
+Implements subscripts.
+
+.. Tip::
+
+   Whitespace or punctuation is required around interpreted text, but
+   often not desired with subscripts & superscripts.
+   Backslash-escaped whitespace can be used; the whitespace will be
+   removed from the processed document::
+
+       H\ :sub:`2`\ O
+       E = mc\ :sup:`2`
+
+   In such cases, readability of the plain text can be greatly
+   improved with substitutions::
+
+       The chemical formula for pure water is |H2O|.
+
+       .. |H2O| replace:: H\ :sub:`2`\ O
+
+   See `the reStructuredText spec`__ for further information on
+   `character-level markup`__ and `the substitution mechanism`__.
+
+   __ restructuredtext.html
+   __ restructuredtext.html#character-level-inline-markup
+   __ restructuredtext.html#substitution-references
+
+
+``:superscript:``
+=================
+
+:Aliases: ``:sup:``
+:DTD Element: superscript
+:Customization:
+    :Options: class_.
+    :Content: None.
+
+Implements superscripts.  See the tip in `:subscript:`_ above.
+
+
+``:title-reference:``
+=====================
+
+:Aliases: ``:title:``, ``:t:``.
+:DTD Element: title_reference
+:Customization:
+    :Options: class_.
+    :Content: None.
+
+The ``:title-reference:`` role is used to describe the titles of
+books, periodicals, and other materials.  It is the equivalent of the
+HTML "cite" element, and it is expected that HTML writers will
+typically render "title_reference" elements using "cite".
+
+Since title references are typically rendered with italics, they are
+often marked up using ``*emphasis*``, which is misleading and vague.
+The "title_reference" element provides accurate and unambiguous
+descriptive markup.
+
+Let's assume ``:title-reference:`` is the default interpreted text
+role (see below) for this example::
+
+    `Design Patterns` [GoF95]_ is an excellent read.
+
+The following document fragment (pseudo-XML_) will result from
+processing::
+
+    <paragraph>
+        <title_reference>
+            Design Patterns
+
+        <citation_reference refname="gof95">
+            GoF95
+         is an excellent read.
+
+``:title-reference:`` is the default interpreted text role in the
+standard reStructuredText parser.  This means that no explicit role is
+required.  Applications of reStructuredText may designate a different
+default role, in which case the explicit ``:title-reference:`` role
+must be used to obtain a ``title_reference`` element.
+
+
+.. _pseudo-XML: ../doctree.html#pseudo-xml
+
+
+-------------------
+ Specialized Roles
+-------------------
+
+``raw``
+=======
+
+:Aliases: None
+:DTD Element: raw
+:Customization:
+    :Options: class_, format
+    :Content: None
+
+.. WARNING::
+
+   The "raw" role is a stop-gap measure allowing the author to bypass
+   reStructuredText's markup.  It is a "power-user" feature that
+   should not be overused or abused.  The use of "raw" ties documents
+   to specific output formats and makes them less portable.
+
+   If you often need to use "raw"-derived interpreted text roles or
+   the "raw" directive, that is a sign either of overuse/abuse or that
+   functionality may be missing from reStructuredText.  Please
+   describe your situation in a message to the Docutils-users_ mailing
+   list.
+
+   .. _Docutils-users: ../../user/mailing-lists.html#docutils-user
+
+The "raw" role indicates non-reStructuredText data that is to be
+passed untouched to the Writer.  It is the inline equivalent of the
+`"raw" directive`_; see its documentation for details on the
+semantics.
+
+.. _"raw" directive: directives.html#raw-directive
+
+The "raw" role cannot be used directly.  The `"role" directive`_ must
+first be used to build custom roles based on the "raw" role.  One or
+more formats (Writer names) must be provided in a "format" option.
+
+For example, the following creates an HTML-specific "raw-html" role::
+
+    .. role:: raw-html(raw)
+       :format: html
+
+This role can now be used directly to pass data untouched to the HTML
+Writer.  For example::
+
+    If there just *has* to be a line break here,
+    :raw-html:`<br />`
+    it can be accomplished with a "raw"-derived role.
+    But the line block syntax should be considered first.
+
+.. Tip:: Roles based on "raw" should clearly indicate their origin, so
+   they are not mistaken for reStructuredText markup.  Using a "raw-"
+   prefix for role names is recommended.
+
+In addition to "class_", the following option is recognized:
+
+``format`` : text
+    One or more space-separated output format names (Writer names).

--- a/tests/test_vectors/roles_expected.html
+++ b/tests/test_vectors/roles_expected.html
@@ -1,0 +1,435 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+.r1 {font-weight: bold}
+.r2 {color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #282a36}
+.r3 {color: #949494; text-decoration-color: #949494}
+.r4 {color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822}
+.r5 {color: #ff4689; text-decoration-color: #ff4689; background-color: #272822}
+.r6 {color: #ed007e; text-decoration-color: #ed007e; background-color: #1e0010}
+.r7 {background-color: #272822}
+.r8 {color: #c6c6c6; text-decoration-color: #c6c6c6; background-color: #121212}
+.r9 {color: #bd93f9; text-decoration-color: #bd93f9; background-color: #282a36; text-decoration: underline}
+.r10 {color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #282a36; font-style: italic}
+.r11 {color: #8be9fd; text-decoration-color: #8be9fd}
+.r12 {color: #ae81ff; text-decoration-color: #ae81ff; background-color: #272822}
+.r13 {color: #66d9ef; text-decoration-color: #66d9ef; background-color: #272822}
+.r14 {color: #50fa7b; text-decoration-color: #50fa7b; font-weight: bold}
+.r15 {color: #e6db74; text-decoration-color: #e6db74; background-color: #272822}
+.r16 {color: #f1fa8c; text-decoration-color: #f1fa8c; font-weight: bold}
+.r17 {color: #bcbcbc; text-decoration-color: #bcbcbc}
+body {
+    color: #f8f8f2;
+    background-color: #282a36;
+}
+</style>
+</head>
+<body>
+    <pre style="font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace"><code style="font-family:inherit"><span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                       reStructuredText Interpreted Text Roles                                        ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name </span>┃<span class="r1"> Field Value                                            </span>┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Author    </span> │ David Goodger                                          │
+├────────────┼────────────────────────────────────────────────────────┤
+│ <span class="r1">Contact   </span> │ docutils-develop@lists.sourceforge.net                 │
+├────────────┼────────────────────────────────────────────────────────┤
+│ <span class="r1">Revision  </span> │ $Revision: 8959 $                                      │
+├────────────┼────────────────────────────────────────────────────────┤
+│ <span class="r1">Date      </span> │ $Date: 2022-01-21 14:45:42 +0100 (Fr, 21. JÃ¤n 2022) $ │
+├────────────┼────────────────────────────────────────────────────────┤
+│ <span class="r1">Copyright </span> │ This document has been placed in the public domain.    │
+└────────────┴────────────────────────────────────────────────────────┘
+<span class="r2">This document describes the interpreted text roles implemented in the reference reStructuredText parser.</span>
+
+<span class="r2">Interpreted text uses backquotes (`) around the text.  An explicit role marker may optionally appear before or after the</span>
+<span class="r2">text, delimited with colons.  For example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">This </span><span class="r5">is</span><span class="r4"> </span><span class="r6">`</span><span class="r4">interpreted text</span><span class="r6">`</span><span class="r4"> using the default role</span><span class="r5">.</span><span class="r7">                                                                  </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r7">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">This </span><span class="r5">is</span><span class="r4"> :title:</span><span class="r6">`</span><span class="r4">interpreted text</span><span class="r6">`</span><span class="r4"> using an explicit role</span><span class="r5">.</span><span class="r7">                                                           </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">A default role may be defined by applications of reStructuredText; it is used if no explicit </span><span class="r8">:role:</span><span class="r2"> prefix or suffix is </span>
+<span class="r2">given.  The &quot;default default role&quot; is </span><span class="r9">:title-reference:</span><span class="r2">.  It can be changed using the </span><a class="r9" href="directives.html#default-role">default-role</a><span class="r2"> directive.</span>
+
+<span class="r2">See the </span><a class="r9" href="restructuredtext.html#interpreted-text">Interpreted Text</a><span class="r2"> section in the </span><a class="r9" href="restructuredtext.html">reStructuredText Markup Specification</a><span class="r2"> for syntax details.  For details on the </span>
+<span class="r2">hierarchy of elements, please see </span><a class="r9" href="../doctree.html">The Docutils Document Tree</a><span class="r2"> and the </span><a class="r9" href="../docutils.dtd">Docutils Generic DTD</a><span class="r2"> XML document type definition. </span>
+<span class="r2">For interpreted text role implementation details, see </span><a class="r9" href="../../howto/rst-roles.html">Creating reStructuredText Interpreted Text Roles</a><span class="r2">.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                       Contents                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                    Customization                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r2">Custom interpreted text roles may be defined in a document with the </span><span class="r9">&quot;role&quot; directive</span><span class="r2">.  Customization details are listed </span>
+<span class="r2">with each role.</span>
+
+<span class="r2">A </span><span class="r8">class</span><span class="r2"> option is recognized by the &quot;role&quot; directive for most interpreted text roles.  A </span><span class="r9">description</span><span class="r2"> is provided in the </span>
+<span class="r9">&quot;role&quot; directive</span><span class="r2"> documentation.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                    Standard Roles                                                    ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      :emphasis:                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name    </span>┃<span class="r1"> Field Value </span>┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
+│ <span class="r1">Aliases      </span> │ None        │
+├───────────────┼─────────────┤
+│ <span class="r1">DTD Element  </span> │ emphasis    │
+├───────────────┼─────────────┤
+│ <span class="r1">Customization</span> │ Options     │
+│               │             │
+│               │ class.      │
+│               │             │
+│               │ Content     │
+│               │             │
+│               │ None.       │
+└───────────────┴─────────────┘
+<span class="r2">Implements emphasis.  These are equivalent:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r5">*</span><span class="r4">text</span><span class="r5">*</span><span class="r7">                                                                                                              </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">:emphasis:</span><span class="r6">`</span><span class="r4">text</span><span class="r6">`</span><span class="r7">                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      :literal:                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name    </span>┃<span class="r1"> Field Value </span>┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
+│ <span class="r1">Aliases      </span> │ None        │
+├───────────────┼─────────────┤
+│ <span class="r1">DTD Element  </span> │ literal     │
+├───────────────┼─────────────┤
+│ <span class="r1">Customization</span> │ Options     │
+│               │             │
+│               │ class.      │
+│               │             │
+│               │ Content     │
+│               │             │
+│               │ None.       │
+└───────────────┴─────────────┘
+<span class="r2">Implements inline literal text.  These are equivalent:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r6">``</span><span class="r4">text</span><span class="r6">``</span><span class="r7">                                                                                                            </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">:literal:</span><span class="r6">`</span><span class="r4">text</span><span class="r6">`</span><span class="r7">                                                                                                     </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">Care must be taken with backslash-escapes though.  These are </span><span class="r10">not</span><span class="r2"> equivalent:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r6">``</span><span class="r4">text \ </span><span class="r5">and</span><span class="r4"> \ backslashes</span><span class="r6">``</span><span class="r7">                                                                                        </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">:literal:</span><span class="r6">`</span><span class="r4">text \ </span><span class="r5">and</span><span class="r4"> \ backslashes</span><span class="r6">`</span><span class="r7">                                                                                 </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">The backslashes in the first line are preserved (and do nothing), whereas the backslashes in the second line escape the </span>
+<span class="r2">following spaces.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                        :code:                                                        ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name    </span>┃<span class="r1"> Field Value     </span>┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Aliases      </span> │ None            │
+├───────────────┼─────────────────┤
+│ <span class="r1">DTD Element  </span> │ literal         │
+├───────────────┼─────────────────┤
+│ <span class="r1">Customization</span> │ Options         │
+│               │                 │
+│               │ class, language │
+│               │                 │
+│               │ Content         │
+│               │                 │
+│               │ None.           │
+└───────────────┴─────────────────┘
+<span class="r2">(New in Docutils 0.9.)</span>
+
+<span class="r2">The </span><span class="r8">code</span><span class="r2"> role marks its content as code in a formal language.</span>
+
+<span class="r2">For syntax highlight of inline code, the </span><span class="r9">&quot;role&quot; directive</span><span class="r2"> can be used to build custom roles with the code language </span>
+<span class="r2">specified in the &quot;language&quot; option.</span>
+
+<span class="r2">For example, the following creates a LaTeX-specific &quot;latex&quot; role:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r5">..</span><span class="r4"> role:: latex(code)</span><span class="r7">                                                                                               </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">   :language: latex</span><span class="r7">                                                                                                 </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">Content of the new role is parsed and tagged by the </span><a class="r9" href="https://pygments.org/">Pygments</a><span class="r2"> syntax highlighter. See the </span><a class="r9" href="directives.html#code">code directive</a><span class="r2"> for more info on</span>
+<span class="r2">parsing and display of code in reStructuredText.</span>
+
+<span class="r2">In addition to &quot;</span><span class="r9">class</span><span class="r2">&quot;, the following option is recognized:</span>
+
+    language : <span class="r11">text</span>
+      Name of the code&#x27;s language. See supported languages and markup formats for recognized values.
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                        :math:                                                        ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name    </span>┃<span class="r1"> Field Value </span>┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
+│ <span class="r1">Aliases      </span> │ None        │
+├───────────────┼─────────────┤
+│ <span class="r1">DTD Element  </span> │ math        │
+├───────────────┼─────────────┤
+│ <span class="r1">Customization</span> │ Options     │
+│               │             │
+│               │ class       │
+│               │             │
+│               │ Content     │
+│               │             │
+│               │ None.       │
+└───────────────┴─────────────┘
+<span class="r2">(New in Docutils 0.8.)</span>
+
+<span class="r2">The </span><span class="r8">math</span><span class="r2"> role marks its content as mathematical notation (inline formula).</span>
+
+<span class="r2">The input format is LaTeX math syntax without the â€œmath delimitersâ€œ (</span><span class="r8">$ $</span><span class="r2">), for example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">The area of a circle </span><span class="r5">is</span><span class="r4"> :math:</span><span class="r6">`</span><span class="r4">A_\text{c} </span><span class="r5">=</span><span class="r4"> (\pi</span><span class="r5">/</span><span class="r12">4</span><span class="r4">) d</span><span class="r5">^</span><span class="r12">2</span><span class="r6">`</span><span class="r5">.</span><span class="r7">                                                           </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">See the </span><a class="r9" href="directives.html#math">math directive</a><span class="r2"> (producing display formulas) for more info on mathematical notation in reStructuredText.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                   :pep-reference:                                                    ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name    </span>┃<span class="r1"> Field Value </span>┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
+│ <span class="r1">Aliases      </span> │ :PEP:       │
+├───────────────┼─────────────┤
+│ <span class="r1">DTD Element  </span> │ reference   │
+├───────────────┼─────────────┤
+│ <span class="r1">Customization</span> │ Options     │
+│               │             │
+│               │ class.      │
+│               │             │
+│               │ Content     │
+│               │             │
+│               │ None.       │
+└───────────────┴─────────────┘
+<span class="r2">The </span><span class="r8">:pep-reference:</span><span class="r2"> role is used to create an HTTP reference to a PEP (Python Enhancement Proposal).  The </span><span class="r8">:PEP:</span><span class="r2"> alias is</span>
+<span class="r2">usually used.  The content must be a number, for example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">See :PEP:</span><span class="r6">`</span><span class="r12">287</span><span class="r6">`</span><span class="r4"> </span><span class="r13">for</span><span class="r4"> more information about reStructuredText</span><span class="r5">.</span><span class="r7">                                                         </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">This is equivalent to:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">See </span><span class="r6">`</span><span class="r4">PEP </span><span class="r12">287</span><span class="r6">`</span><span class="r4">__ </span><span class="r13">for</span><span class="r4"> more information about reStructuredText</span><span class="r5">.</span><span class="r7">                                                        </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r7">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">__ https:</span><span class="r5">//</span><span class="r4">www</span><span class="r5">.</span><span class="r4">python</span><span class="r5">.</span><span class="r4">org</span><span class="r5">/</span><span class="r4">dev</span><span class="r5">/</span><span class="r4">peps</span><span class="r5">/</span><span class="r4">pep</span><span class="r5">-</span><span class="r12">0287</span><span class="r7">                                                                         </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                   :rfc-reference:                                                    ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name    </span>┃<span class="r1"> Field Value </span>┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
+│ <span class="r1">Aliases      </span> │ :RFC:       │
+├───────────────┼─────────────┤
+│ <span class="r1">DTD Element  </span> │ reference   │
+├───────────────┼─────────────┤
+│ <span class="r1">Customization</span> │ Options     │
+│               │             │
+│               │ class.      │
+│               │             │
+│               │ Content     │
+│               │             │
+│               │ None.       │
+└───────────────┴─────────────┘
+<span class="r2">The </span><span class="r8">:rfc-reference:</span><span class="r2"> role is used to create an HTTP reference to an RFC (Internet Request for Comments).  The </span><span class="r8">:RFC:</span><span class="r2"> alias</span>
+<span class="r2">is usually used.  The content must be a number , for example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">See :RFC:</span><span class="r6">`</span><span class="r12">2822</span><span class="r6">`</span><span class="r4"> </span><span class="r13">for</span><span class="r4"> information about email headers</span><span class="r5">.</span><span class="r7">                                                                </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">This is equivalent to:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">See </span><span class="r6">`</span><span class="r4">RFC </span><span class="r12">2822</span><span class="r6">`</span><span class="r4">__ </span><span class="r13">for</span><span class="r4"> information about email headers</span><span class="r5">.</span><span class="r7">                                                               </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r7">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">__ https:</span><span class="r5">//</span><span class="r4">tools</span><span class="r5">.</span><span class="r4">ietf</span><span class="r5">.</span><span class="r4">org</span><span class="r5">/</span><span class="r4">html</span><span class="r5">/</span><span class="r4">rfc2822</span><span class="r5">.</span><span class="r4">html</span><span class="r7">                                                                         </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                       :strong:                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name    </span>┃<span class="r1"> Field Value </span>┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
+│ <span class="r1">Aliases      </span> │ None        │
+├───────────────┼─────────────┤
+│ <span class="r1">DTD Element  </span> │ strong      │
+├───────────────┼─────────────┤
+│ <span class="r1">Customization</span> │ Options     │
+│               │             │
+│               │ class.      │
+│               │             │
+│               │ Content     │
+│               │             │
+│               │ None.       │
+└───────────────┴─────────────┘
+<span class="r2">Implements strong emphasis.  These are equivalent:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r5">**</span><span class="r4">text</span><span class="r5">**</span><span class="r7">                                                                                                            </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">:strong:</span><span class="r6">`</span><span class="r4">text</span><span class="r6">`</span><span class="r7">                                                                                                      </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     :subscript:                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name    </span>┃<span class="r1"> Field Value </span>┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
+│ <span class="r1">Aliases      </span> │ :sub:       │
+├───────────────┼─────────────┤
+│ <span class="r1">DTD Element  </span> │ subscript   │
+├───────────────┼─────────────┤
+│ <span class="r1">Customization</span> │ Options     │
+│               │             │
+│               │ class.      │
+│               │             │
+│               │ Content     │
+│               │             │
+│               │ None.       │
+└───────────────┴─────────────┘
+<span class="r2">Implements subscripts.</span>
+
+<span class="r14">╭─────────────────────────────────────────────────────── Tip:  ────────────────────────────────────────────────────────╮</span>
+<span class="r14">│ Whitespace or punctuation is required around interpreted text, but often not desired with subscripts &amp; superscripts. │</span>
+<span class="r14">│ Backslash-escaped whitespace can be used; the whitespace will be removed from the processed document:  H\ :sub:`2`\  │</span>
+<span class="r14">│ O E = mc\ :sup:`2`  In such cases, readability of the plain text can be greatly improved with substitutions:  The    │</span>
+<span class="r14">│ chemical formula for pure water is |H2O|.  .. |H2O| replace:: H\ :sub:`2`\ O  See the reStructuredText spec for      │</span>
+<span class="r14">│ further information on character-level markup and the substitution mechanism.                                        │</span>
+<span class="r14">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                    :superscript:                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name    </span>┃<span class="r1"> Field Value </span>┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
+│ <span class="r1">Aliases      </span> │ :sup:       │
+├───────────────┼─────────────┤
+│ <span class="r1">DTD Element  </span> │ superscript │
+├───────────────┼─────────────┤
+│ <span class="r1">Customization</span> │ Options     │
+│               │             │
+│               │ class.      │
+│               │             │
+│               │ Content     │
+│               │             │
+│               │ None.       │
+└───────────────┴─────────────┘
+<span class="r2">Implements superscripts.  See the tip in </span><span class="r9">:subscript:</span><span class="r2"> above.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                  :title-reference:                                                   ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name    </span>┃<span class="r1"> Field Value     </span>┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Aliases      </span> │ :title:, :t:.   │
+├───────────────┼─────────────────┤
+│ <span class="r1">DTD Element  </span> │ title_reference │
+├───────────────┼─────────────────┤
+│ <span class="r1">Customization</span> │ Options         │
+│               │                 │
+│               │ class.          │
+│               │                 │
+│               │ Content         │
+│               │                 │
+│               │ None.           │
+└───────────────┴─────────────────┘
+<span class="r2">The </span><span class="r8">:title-reference:</span><span class="r2"> role is used to describe the titles of books, periodicals, and other materials.  It is the </span>
+<span class="r2">equivalent of the HTML &quot;cite&quot; element, and it is expected that HTML writers will typically render &quot;title_reference&quot; </span>
+<span class="r2">elements using &quot;cite&quot;.</span>
+
+<span class="r2">Since title references are typically rendered with italics, they are often marked up using </span><span class="r8">*emphasis*</span><span class="r2">, which is </span>
+<span class="r2">misleading and vague. The &quot;title_reference&quot; element provides accurate and unambiguous descriptive markup.</span>
+
+<span class="r2">Let&#x27;s assume </span><span class="r8">:title-reference:</span><span class="r2"> is the default interpreted text role (see below) for this example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r6">`</span><span class="r4">Design Patterns</span><span class="r6">`</span><span class="r4"> [GoF95]_ </span><span class="r5">is</span><span class="r4"> an excellent read</span><span class="r5">.</span><span class="r7">                                                                    </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">The following document fragment (</span><a class="r9" href="../doctree.html#pseudo-xml">pseudo-XML</a><span class="r2">) will result from processing:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r5">&lt;</span><span class="r4">paragraph</span><span class="r5">&gt;</span><span class="r7">                                                                                                         </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">    </span><span class="r5">&lt;</span><span class="r4">title_reference</span><span class="r5">&gt;</span><span class="r7">                                                                                               </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">        Design Patterns</span><span class="r7">                                                                                             </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r7">                                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">    </span><span class="r5">&lt;</span><span class="r4">citation_reference refname</span><span class="r5">=</span><span class="r15">&quot;gof95&quot;</span><span class="r5">&gt;</span><span class="r7">                                                                            </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">        GoF95</span><span class="r7">                                                                                                       </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">     </span><span class="r5">is</span><span class="r4"> an excellent read</span><span class="r5">.</span><span class="r7">                                                                                          </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r8">:title-reference:</span><span class="r2"> is the default interpreted text role in the standard reStructuredText parser.  This means that no </span>
+<span class="r2">explicit role is required.  Applications of reStructuredText may designate a different default role, in which case the </span>
+<span class="r2">explicit </span><span class="r8">:title-reference:</span><span class="r2"> role must be used to obtain a </span><span class="r8">title_reference</span><span class="r2"> element.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                  Specialized Roles                                                   ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                         raw                                                          ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name    </span>┃<span class="r1"> Field Value   </span>┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
+│ <span class="r1">Aliases      </span> │ None          │
+├───────────────┼───────────────┤
+│ <span class="r1">DTD Element  </span> │ raw           │
+├───────────────┼───────────────┤
+│ <span class="r1">Customization</span> │ Options       │
+│               │               │
+│               │ class, format │
+│               │               │
+│               │ Content       │
+│               │               │
+│               │ None          │
+└───────────────┴───────────────┘
+<span class="r16">╭───────────────────────────────────────────────────── Warning:  ──────────────────────────────────────────────────────╮</span>
+<span class="r16">│ The &quot;raw&quot; role is a stop-gap measure allowing the author to bypass reStructuredText&#x27;s markup.  It is a &quot;power-user&quot;  │</span>
+<span class="r16">│ feature that should not be overused or abused.  The use of &quot;raw&quot; ties documents to specific output formats and makes │</span>
+<span class="r16">│ them less portable.  If you often need to use &quot;raw&quot;-derived interpreted text roles or the &quot;raw&quot; directive, that is a │</span>
+<span class="r16">│ sign either of overuse/abuse or that functionality may be missing from reStructuredText.  Please describe your       │</span>
+<span class="r16">│ situation in a message to the Docutils-users mailing list.                                                           │</span>
+<span class="r16">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r2">The &quot;raw&quot; role indicates non-reStructuredText data that is to be passed untouched to the Writer.  It is the inline </span>
+<span class="r2">equivalent of the </span><a class="r9" href="directives.html#raw-directive">&quot;raw&quot; directive</a><span class="r2">; see its documentation for details on the semantics.</span>
+
+<span class="r2">The &quot;raw&quot; role cannot be used directly.  The </span><span class="r9">&quot;role&quot; directive</span><span class="r2"> must first be used to build custom roles based on the </span>
+<span class="r2">&quot;raw&quot; role.  One or more formats (Writer names) must be provided in a &quot;format&quot; option.</span>
+
+<span class="r2">For example, the following creates an HTML-specific &quot;raw-html&quot; role:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r5">..</span><span class="r4"> role:: raw</span><span class="r5">-</span><span class="r4">html(raw)</span><span class="r7">                                                                                             </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">   :format: html</span><span class="r7">                                                                                                    </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r2">This role can now be used directly to pass data untouched to the HTML Writer.  For example:</span>
+<span class="r3">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r3">│</span> <span class="r4">If there just </span><span class="r5">*</span><span class="r4">has</span><span class="r5">*</span><span class="r4"> to be a line </span><span class="r13">break</span><span class="r4"> here,</span><span class="r7">                                                                        </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">:raw</span><span class="r5">-</span><span class="r4">html:</span><span class="r6">`</span><span class="r5">&lt;</span><span class="r4">br </span><span class="r5">/&gt;</span><span class="r6">`</span><span class="r7">                                                                                                  </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">it can be accomplished </span><span class="r13">with</span><span class="r4"> a </span><span class="r15">&quot;raw&quot;</span><span class="r5">-</span><span class="r4">derived role</span><span class="r5">.</span><span class="r7">                                                                   </span> <span class="r3">│</span>
+<span class="r3">│</span> <span class="r4">But the line block syntax should be considered first</span><span class="r5">.</span><span class="r7">                                                               </span> <span class="r3">│</span>
+<span class="r3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r14">╭─────────────────────────────────────────────────────── Tip:  ────────────────────────────────────────────────────────╮</span>
+<span class="r14">│ Roles based on &quot;raw&quot; should clearly indicate their origin, so they are not mistaken for reStructuredText markup.     │</span>
+<span class="r14">│ Using a &quot;raw-&quot; prefix for role names is recommended.                                                                 │</span>
+<span class="r14">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r2">In addition to &quot;</span><span class="r9">class</span><span class="r2">&quot;, the following option is recognized:</span>
+
+    format : <span class="r11">text</span>
+      One or more space-separated output format names (Writer names).
+
+<span class="r17">┌─────────────────────────────────────────────────────── Footer ───────────────────────────────────────────────────────┐</span>
+<span class="r17">│</span>                           You can link to a specific section by saying                                               <span class="r17">│</span>
+<span class="r17">│</span>                           :rfc:`number#anchor`. (New in Docutils 0.15.)                                              <span class="r17">│</span>
+<span class="r17">│</span>                                                                                                                      <span class="r17">│</span>
+<span class="r17">│</span>                           The anchor (anything following a #) is appended to                                         <span class="r17">│</span>
+<span class="r17">│</span>                           the reference without any checks and not shown in the link text.                           <span class="r17">│</span>
+<span class="r17">│</span>                                                                                                                      <span class="r17">│</span>
+<span class="r17">│</span>                           It is recommended to use hyperlink references for                                          <span class="r17">│</span>
+<span class="r17">│</span>                           anything more complex than a single RFC number.                                            <span class="r17">│</span>
+<span class="r17">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+</code></pre>
+</body>
+</html>

--- a/tests/test_vectors/roles_expected.html
+++ b/tests/test_vectors/roles_expected.html
@@ -419,7 +419,6 @@ body {
 
     format : <span class="r11">text</span>
       One or more space-separated output format names (Writer names).
-
 <span class="r17">┌─────────────────────────────────────────────────────── Footer ───────────────────────────────────────────────────────┐</span>
 <span class="r17">│</span>                           You can link to a specific section by saying                                               <span class="r17">│</span>
 <span class="r17">│</span>                           :rfc:`number#anchor`. (New in Docutils 0.15.)                                              <span class="r17">│</span>

--- a/tests/test_vectors/specification.rst
+++ b/tests/test_vectors/specification.rst
@@ -1,0 +1,3267 @@
+.. -*- coding: utf-8 -*-
+
+=======================================
+ reStructuredText Markup Specification
+=======================================
+
+:Author: David Goodger
+:Contact: docutils-develop@lists.sourceforge.net
+:Revision: $Revision: 8959 $
+:Date: $Date: 2022-01-21 14:45:42 +0100 (Fr, 21. JÃ¤n 2022) $
+:Copyright: This document has been placed in the public domain.
+
+.. Note::
+
+   This document is a detailed technical specification; it is not a
+   tutorial or a primer.  If this is your first exposure to
+   reStructuredText, please read `A ReStructuredText Primer`_ and the
+   `Quick reStructuredText`_ user reference first.
+
+.. _A ReStructuredText Primer: ../../user/rst/quickstart.html
+.. _Quick reStructuredText: ../../user/rst/quickref.html
+
+
+reStructuredText_ is plaintext that uses simple and intuitive
+constructs to indicate the structure of a document.  These constructs
+are equally easy to read in raw and processed forms.  This document is
+itself an example of reStructuredText (raw, if you are reading the
+text file, or processed, if you are reading an HTML document, for
+example).  The reStructuredText parser is a component of Docutils_.
+
+Simple, implicit markup is used to indicate special constructs, such
+as section headings, bullet lists, and emphasis.  The markup used is
+as minimal and unobtrusive as possible.  Less often-used constructs
+and extensions to the basic reStructuredText syntax may have more
+elaborate or explicit markup.
+
+reStructuredText is applicable to documents of any length, from the
+very small (such as inline program documentation fragments, e.g.
+Python docstrings) to the quite large (this document).
+
+The first section gives a quick overview of the syntax of the
+reStructuredText markup by example.  A complete specification is given
+in the `Syntax Details`_ section.
+
+`Literal blocks`_ (in which no markup processing is done) are used for
+examples throughout this document, to illustrate the plaintext markup.
+
+
+.. contents::
+
+
+-----------------------
+ Quick Syntax Overview
+-----------------------
+
+A reStructuredText document is made up of body or block-level
+elements, and may be structured into sections.  Sections_ are
+indicated through title style (underlines & optional overlines).
+Sections contain body elements and/or subsections.  Some body elements
+contain further elements, such as lists containing list items, which
+in turn may contain paragraphs and other body elements.  Others, such
+as paragraphs, contain text and `inline markup`_ elements.
+
+Here are examples of `body elements`_:
+
+- Paragraphs_ (and `inline markup`_)::
+
+      Paragraphs contain text and may contain inline markup:
+      *emphasis*, **strong emphasis**, `interpreted text`, ``inline
+      literals``, standalone hyperlinks (https://www.python.org),
+      external hyperlinks (Python_), internal cross-references
+      (example_), footnote references ([1]_), citation references
+      ([CIT2002]_), substitution references (|example|), and _`inline
+      internal targets`.
+
+      Paragraphs are separated by blank lines and are left-aligned.
+
+- Five types of lists:
+
+  1. `Bullet lists`_::
+
+         - This is a bullet list.
+
+         - Bullets can be "*", "+", or "-".
+
+  2. `Enumerated lists`_::
+
+         1. This is an enumerated list.
+
+         2. Enumerators may be arabic numbers, letters, or roman
+            numerals.
+
+  3. `Definition lists`_::
+
+         what
+             Definition lists associate a term with a definition.
+
+         how
+             The term is a one-line phrase, and the definition is one
+             or more paragraphs or body elements, indented relative to
+             the term.
+
+  4. `Field lists`_::
+
+         :what: Field lists map field names to field bodies, like
+                database records.  They are often part of an extension
+                syntax.
+
+         :how: The field marker is a colon, the field name, and a
+               colon.
+
+               The field body may contain one or more body elements,
+               indented relative to the field marker.
+
+  5. `Option lists`_, for listing command-line options::
+
+         -a            command-line option "a"
+         -b file       options can have arguments
+                       and long descriptions
+         --long        options can be long also
+         --input=file  long options can also have
+                       arguments
+         /V            DOS/VMS-style options too
+
+     There must be at least two spaces between the option and the
+     description.
+
+- `Literal blocks`_::
+
+      Literal blocks are either indented or line-prefix-quoted blocks,
+      and indicated with a double-colon ("::") at the end of the
+      preceding paragraph (right here -->)::
+
+          if literal_block:
+              text = 'is left as-is'
+              spaces_and_linebreaks = 'are preserved'
+              markup_processing = None
+
+- `Block quotes`_::
+
+      Block quotes consist of indented body elements:
+
+          This theory, that is mine, is mine.
+
+          -- Anne Elk (Miss)
+
+- `Doctest blocks`_::
+
+      >>> print 'Python-specific usage examples; begun with ">>>"'
+      Python-specific usage examples; begun with ">>>"
+      >>> print '(cut and pasted from interactive Python sessions)'
+      (cut and pasted from interactive Python sessions)
+
+- Two syntaxes for tables_:
+
+  1. `Grid tables`_; complete, but complex and verbose::
+
+         +------------------------+------------+----------+
+         | Header row, column 1   | Header 2   | Header 3 |
+         +========================+============+==========+
+         | body row 1, column 1   | column 2   | column 3 |
+         +------------------------+------------+----------+
+         | body row 2             | Cells may span        |
+         +------------------------+-----------------------+
+
+  2. `Simple tables`_; easy and compact, but limited::
+
+         ====================  ==========  ==========
+         Header row, column 1  Header 2    Header 3
+         ====================  ==========  ==========
+         body row 1, column 1  column 2    column 3
+         body row 2            Cells may span columns
+         ====================  ======================
+
+- `Explicit markup blocks`_ all begin with an explicit block marker,
+  two periods and a space:
+
+  - Footnotes_::
+
+        .. [1] A footnote contains body elements, consistently
+           indented by at least 3 spaces.
+
+  - Citations_::
+
+        .. [CIT2002] Just like a footnote, except the label is
+           textual.
+
+  - `Hyperlink targets`_::
+
+        .. _Python: https://www.python.org
+
+        .. _example:
+
+        The "_example" target above points to this paragraph.
+
+  - Directives_::
+
+        .. image:: mylogo.png
+
+  - `Substitution definitions`_::
+
+        .. |symbol here| image:: symbol.png
+
+  - Comments_::
+
+        .. Comments begin with two dots and a space.  Anything may
+           follow, except for the syntax of footnotes/citations,
+           hyperlink targets, directives, or substitution definitions.
+
+
+----------------
+ Syntax Details
+----------------
+
+Descriptions below list "doctree elements" (document tree element
+names; XML DTD generic identifiers) corresponding to syntax
+constructs.  For details on the hierarchy of elements, please see `The
+Docutils Document Tree`_ and the `Docutils Generic DTD`_ XML document
+type definition.
+
+
+Whitespace
+==========
+
+Spaces are recommended for indentation_, but tabs may also be used.
+Tabs will be converted to spaces.  Tab stops are at every 8th column
+(processing systems may make this value configurable).
+
+Other whitespace characters (form feeds [chr(12)] and vertical tabs
+[chr(11)]) are converted to single spaces before processing.
+
+
+Blank Lines
+-----------
+
+Blank lines are used to separate paragraphs and other elements.
+Multiple successive blank lines are equivalent to a single blank line,
+except within literal blocks (where all whitespace is preserved).
+Blank lines may be omitted when the markup makes element separation
+unambiguous, in conjunction with indentation.  The first line of a
+document is treated as if it is preceded by a blank line, and the last
+line of a document is treated as if it is followed by a blank line.
+
+
+Indentation
+-----------
+
+Indentation is used to indicate -- and is only significant in
+indicating -- block quotes, definitions (in `definition lists`_),
+and local nested content:
+
+- list item content (multi-line contents of list items, and multiple
+  body elements within a list item, including nested lists),
+- the content of `literal blocks`_, and
+- the content of `explicit markup blocks`_ (directives, footnotes, ...).
+
+Any text whose indentation is less than that of the current level
+(i.e., unindented text or "dedents") ends the current level of
+indentation.
+
+Since all indentation is significant, the level of indentation must be
+consistent.  For example, indentation is the sole markup indicator for
+`block quotes`_::
+
+    This is a top-level paragraph.
+
+        This paragraph belongs to a first-level block quote.
+
+        Paragraph 2 of the first-level block quote.
+
+Multiple levels of indentation within a block quote will result in
+more complex structures::
+
+    This is a top-level paragraph.
+
+        This paragraph belongs to a first-level block quote.
+
+            This paragraph belongs to a second-level block quote.
+
+    Another top-level paragraph.
+
+            This paragraph belongs to a second-level block quote.
+
+        This paragraph belongs to a first-level block quote.  The
+        second-level block quote above is inside this first-level
+        block quote.
+
+When a paragraph or other construct consists of more than one line of
+text, the lines must be left-aligned::
+
+    This is a paragraph.  The lines of
+    this paragraph are aligned at the left.
+
+        This paragraph has problems.  The
+    lines are not left-aligned.  In addition
+      to potential misinterpretation, warning
+        and/or error messages will be generated
+      by the parser.
+
+Several constructs begin with a marker, and the body of the construct
+must be indented relative to the marker.  For constructs using simple
+markers (`bullet lists`_, `enumerated lists`_), the level of
+indentation of the body is determined by the position of the first
+line of text. For example::
+
+    - This is the first line of a bullet list
+      item's paragraph.  All lines must align
+      relative to the first line.
+
+          This indented paragraph is interpreted
+          as a block quote.
+
+      Another paragraph belonging to the first list item.
+
+     Because it is not sufficiently indented,
+     this paragraph does not belong to the list
+     item (it's a block quote following the list).
+
+The body of `explicit markup blocks`_, `field lists`_, and `option
+lists`_ ends above the first line with the same or less indentation
+than the marker.  For example, field lists may have very long markers
+(containing the field names)::
+
+    :Hello: This field has a short field name, so aligning the field
+            body with the first line is feasible.
+
+    :Number-of-African-swallows-required-to-carry-a-coconut: It would
+        be very difficult to align the field body with the left edge
+        of the first line.  It may even be preferable not to begin the
+        body on the same line as the marker.
+
+
+.. _escape:
+
+Escaping Mechanism
+==================
+
+The character set universally available to plaintext documents, 7-bit
+ASCII, is limited.  No matter what characters are used for markup,
+they will already have multiple meanings in written text.  Therefore
+markup characters will sometimes appear in text without being
+intended as markup.  Any serious markup system requires an escaping
+mechanism to override the default meaning of the characters used for
+the markup.  In reStructuredText we use the *backslash*, commonly used
+as an escaping character in other domains.
+
+A backslash (``\``) escapes the following character.
+
+* "Escaping" backslash characters are represented by NULL characters in
+  the `Document Tree`_ and removed from the output document by the
+  Docutils writers_.
+
+* Escaped non-white characters are prevented from playing a role in any
+  markup interpretation. The escaped character represents the character
+  itself. (A literal backslash can be specified by two backslashes in a
+  row -- the first backslash escapes the second. [#caveat]_)
+
+* Escaped whitespace characters are removed from the output document
+  together with the escaping backslash. This allows for `character-level
+  inline markup`_.
+
+  In `URI context` [#uri-context]_, backslash-escaped whitespace
+  represents a single space.
+
+Backslashes have no special meaning in `literal context` [#literal-context]_.
+Here, a single backslash represents a literal backslash, without having
+to double up. [#caveat]_
+
+.. [#caveat] Please note that the reStructuredText specification and
+   parser do not address the issue of the representation or extraction of
+   text input (how and in what form the text actually *reaches* the
+   parser). Backslashes and other characters may serve a
+   character-escaping purpose in certain contexts and must be dealt with
+   appropriately.  For example, Python uses backslashes in string
+   literals to escape certain characters. The simplest solution when
+   backslashes appear in Python docstrings is to use raw docstrings::
+
+     r"""This is a raw docstring.  Backslashes (\) are not touched."""
+
+.. [#uri-context] In contexts where Docutils expects a URI (the link
+   block of `external hyperlink targets`_ or the argument of an image_ or
+   figure_ directive), whitespace is ignored by default
+
+.. [#literal-context] In literal context (`literal blocks`_ and `inline
+   literals`_, content of the code_, math_, and raw_ directives, content
+   of the `"raw" role`_ and `custom roles`_ based on it),
+   reStructuredText markup characters lose their semantics so there is no
+   reason to escape them.
+
+.. _reference name:
+
+Reference Names
+===============
+
+`Reference names` identify elements for cross-referencing.
+
+.. Note:: References to a target position in external, generated documents
+   must use the auto-generated `identifier key`_ which may differ from the
+   `reference name` due to restrictions on identifiers/labels in the
+   output format.
+
+Simple reference names are single words consisting of alphanumerics
+plus isolated (no two adjacent) internal hyphens, underscores,
+periods, colons and plus signs; no whitespace or other characters are
+allowed.  Footnote labels (Footnotes_ & `Footnote References`_), citation
+labels (Citations_ & `Citation References`_), `interpreted text`_ roles,
+and some `hyperlink references`_ use the simple reference name syntax.
+
+Reference names using punctuation or whose names are phrases (two or
+more space-separated words) are called "phrase-references".
+Phrase-references are expressed by enclosing the phrase in backquotes
+and treating the backquoted text as a reference name::
+
+    Want to learn about `my favorite programming language`_?
+
+    .. _my favorite programming language: https://www.python.org
+
+Simple reference names may also optionally use backquotes.
+
+.. _`normalized reference names`:
+
+Reference names are whitespace-neutral and case-insensitive.  When
+resolving reference names internally:
+
+- whitespace is normalized (one or more spaces, horizontal or vertical
+  tabs, newlines, carriage returns, or form feeds, are interpreted as
+  a single space), and
+
+- case is normalized (all alphabetic characters are converted to
+  lowercase).
+
+For example, the following `hyperlink references`_ are equivalent::
+
+    - `A HYPERLINK`_
+    - `a    hyperlink`_
+    - `A
+      Hyperlink`_
+
+Hyperlinks_, footnotes_, and citations_ all share the same namespace
+for reference names.  The labels of citations (simple reference names)
+and manually-numbered footnotes (numbers) are entered into the same
+database as other hyperlink names.  This means that a footnote_
+(defined as "``.. [#note]``") which can be referred to by a footnote
+reference (``[#note]_``), can also be referred to by a plain hyperlink
+reference (``note_``).  Of course, each type of reference (hyperlink,
+footnote, citation) may be processed and rendered differently.  Some
+care should be taken to avoid reference name conflicts.
+
+
+Document Structure
+==================
+
+Document
+--------
+
+Doctree element: `document <document element_>`_.
+
+
+The top-level element of a parsed reStructuredText document is the
+"document" element.  After initial parsing, the document element is a
+simple container for a document fragment, consisting of `body
+elements`_, transitions_, and sections_, but lacking a document title
+or other bibliographic elements.  The code that calls the parser may
+choose to run one or more optional post-parse transforms_,
+rearranging the document fragment into a complete document with a
+title and possibly other metadata elements (author, date, etc.; see
+`Bibliographic Fields`_).
+
+.. _document title:
+
+Specifically, there is no way to indicate a document title and
+subtitle explicitly in reStructuredText. [#]_ Instead, a lone top-level
+section title (see Sections_ below) can be treated as the document
+title.  Similarly, a lone second-level section title immediately after
+the "document title" can become the document subtitle.  The rest of
+the sections are then lifted up a level or two.  See the `DocTitle
+transform`_ for details.
+
+.. [#] The `"title" configuration setting`__ and the `"title"
+   directive`__ set the document's `title attribute`_ that does not
+   become part of the document body.
+
+   .. _title attribute: ../doctree.html#title-attribute
+   __ ../../user/config.html#title
+   __ directives.html#metadata-document-title
+
+
+Sections
+--------
+
+Doctree elements: section_, title_.
+
+Sections are identified through their titles, which are marked up with
+adornment: "underlines" below the title text, or underlines and
+matching "overlines" above the title.  An underline/overline is a
+single repeated punctuation character that begins in column 1 and
+forms a line extending at least as far as the right edge of the title
+text. [#]_  Specifically, an underline/overline character may be any
+non-alphanumeric printable 7-bit ASCII character [#]_.  When an
+overline is used, the length and character used must match the
+underline.  Underline-only adornment styles are distinct from
+overline-and-underline styles that use the same character.  There may
+be any number of levels of section titles, although some output
+formats may have limits (HTML has 6 levels).
+
+.. [#] The key is the visual length of the title in a mono-spaced font.
+   The adornment may need more or less characters than title, if the
+   title contains wide__ or combining__ characters.
+
+.. [#] The following are all valid section title adornment
+   characters::
+
+       ! " # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \ ] ^ _ ` { | } ~
+
+   Some characters are more suitable than others.  The following are
+   recommended::
+
+       = - ` : . ' " ~ ^ _ * + #
+
+__ https://en.wikipedia.org/wiki/Halfwidth_and_fullwidth_forms#In_Unicode
+__ https://en.wikipedia.org/wiki/Combining_character
+
+Rather than imposing a fixed number and order of section title
+adornment styles, the order enforced will be the order as encountered.
+The first style encountered will be an outermost title (like HTML H1),
+the second style will be a subtitle, the third will be a subsubtitle,
+and so on.
+
+Below are examples of section title styles::
+
+    ===============
+     Section Title
+    ===============
+
+    ---------------
+     Section Title
+    ---------------
+
+    Section Title
+    =============
+
+    Section Title
+    -------------
+
+    Section Title
+    `````````````
+
+    Section Title
+    '''''''''''''
+
+    Section Title
+    .............
+
+    Section Title
+    ~~~~~~~~~~~~~
+
+    Section Title
+    *************
+
+    Section Title
+    +++++++++++++
+
+    Section Title
+    ^^^^^^^^^^^^^
+
+When a title has both an underline and an overline, the title text may
+be inset, as in the first two examples above.  This is merely
+aesthetic and not significant.  Underline-only title text may *not* be
+inset.
+
+A blank line after a title is optional.  All text blocks up to the
+next title of the same or higher level are included in a section (or
+subsection, etc.).
+
+All section title styles need not be used, nor need any specific
+section title style be used.  However, a document must be consistent
+in its use of section titles: once a hierarchy of title styles is
+established, sections must use that hierarchy.
+
+Each section title automatically generates a hyperlink target pointing
+to the section.  The text of the hyperlink target (the "reference
+name") is the same as that of the section title.  See `Implicit
+Hyperlink Targets`_ for a complete description.
+
+Sections may contain `body elements`_, transitions_, and nested
+sections.
+
+
+Transitions
+-----------
+
+Doctree element: transition_.
+
+    Instead of subheads, extra space or a type ornament between
+    paragraphs may be used to mark text divisions or to signal
+    changes in subject or emphasis.
+
+    (The Chicago Manual of Style, 14th edition, section 1.80)
+
+Transitions are commonly seen in novels and short fiction, as a gap
+spanning one or more lines, with or without a type ornament such as a
+row of asterisks.  Transitions separate other body elements.  A
+transition should not begin or end a section or document, nor should
+two transitions be immediately adjacent.
+
+The syntax for a transition marker is a horizontal line of 4 or more
+repeated punctuation characters.  The syntax is the same as section
+title underlines without title text.  Transition markers require blank
+lines before and after::
+
+    Para.
+
+    ----------
+
+    Para.
+
+Unlike section title underlines, no hierarchy of transition markers is
+enforced, nor do differences in transition markers accomplish
+anything.  It is recommended that a single consistent style be used.
+
+The processing system is free to render transitions in output in any
+way it likes.  For example, horizontal rules (``<hr>``) in HTML output
+would be an obvious choice.
+
+
+Body Elements
+=============
+
+Paragraphs
+----------
+
+Doctree element: paragraph_.
+
+Paragraphs consist of blocks of left-aligned text with no markup
+indicating any other body element.  Blank lines separate paragraphs
+from each other and from other body elements.  Paragraphs may contain
+`inline markup`_.
+
+Syntax diagram::
+
+    +------------------------------+
+    | paragraph                    |
+    |                              |
+    +------------------------------+
+
+    +------------------------------+
+    | paragraph                    |
+    |                              |
+    +------------------------------+
+
+
+Bullet Lists
+------------
+
+Doctree elements: bullet_list_, list_item_.
+
+A text block which begins with a "*", "+", "-", "â€¢", "â€£", or "âƒ",
+followed by whitespace, is a bullet list item (a.k.a. "unordered" list
+item).  List item bodies must be left-aligned and indented relative to
+the bullet; the text immediately after the bullet determines the
+indentation.  For example::
+
+    - This is the first bullet list item.  The blank line above the
+      first list item is required; blank lines between list items
+      (such as below this paragraph) are optional.
+
+    - This is the first paragraph in the second item in the list.
+
+      This is the second paragraph in the second item in the list.
+      The blank line above this paragraph is required.  The left edge
+      of this paragraph lines up with the paragraph above, both
+      indented relative to the bullet.
+
+      - This is a sublist.  The bullet lines up with the left edge of
+        the text blocks above.  A sublist is a new list so requires a
+        blank line above and below.
+
+    - This is the third item of the main list.
+
+    This paragraph is not part of the list.
+
+Here are examples of **incorrectly** formatted bullet lists::
+
+    - This first line is fine.
+    A blank line is required between list items and paragraphs.
+    (Warning)
+
+    - The following line appears to be a new sublist, but it is not:
+      - This is a paragraph continuation, not a sublist (since there's
+        no blank line).  This line is also incorrectly indented.
+      - Warnings may be issued by the implementation.
+
+Syntax diagram::
+
+    +------+-----------------------+
+    | "- " | list item             |
+    +------| (body elements)+      |
+           +-----------------------+
+
+
+Enumerated Lists
+----------------
+
+Doctree elements: enumerated_list_, list_item_.
+
+Enumerated lists (a.k.a. "ordered" lists) are similar to bullet lists,
+but use enumerators instead of bullets.  An enumerator consists of an
+enumeration sequence member and formatting, followed by whitespace.
+The following enumeration sequences are recognized:
+
+- arabic numerals: 1, 2, 3, ... (no upper limit).
+- uppercase alphabet characters: A, B, C, ..., Z.
+- lower-case alphabet characters: a, b, c, ..., z.
+- uppercase Roman numerals: I, II, III, IV, ..., MMMMCMXCIX (4999).
+- lowercase Roman numerals: i, ii, iii, iv, ..., mmmmcmxcix (4999).
+
+In addition, the auto-enumerator, "#", may be used to automatically
+enumerate a list.  Auto-enumerated lists may begin with explicit
+enumeration, which sets the sequence.  Fully auto-enumerated lists use
+arabic numerals and begin with 1.  (Auto-enumerated lists are new in
+Docutils 0.3.8.)
+
+The following formatting types are recognized:
+
+- suffixed with a period: "1.", "A.", "a.", "I.", "i.".
+- surrounded by parentheses: "(1)", "(A)", "(a)", "(I)", "(i)".
+- suffixed with a right-parenthesis: "1)", "A)", "a)", "I)", "i)".
+
+While parsing an enumerated list, a new list will be started whenever:
+
+- An enumerator is encountered which does not have the same format and
+  sequence type as the current list (e.g. "1.", "(a)" produces two
+  separate lists).
+
+- The enumerators are not in sequence (e.g., "1.", "3." produces two
+  separate lists).
+
+It is recommended that the enumerator of the first list item be
+ordinal-1 ("1", "A", "a", "I", or "i").  Although other start-values
+will be recognized, they may not be supported by the output format.  A
+level-1 [info] system message will be generated for any list beginning
+with a non-ordinal-1 enumerator.
+
+Lists using Roman numerals must begin with "I"/"i" or a
+multi-character value, such as "II" or "XV".  Any other
+single-character Roman numeral ("V", "X", "L", "C", "D", "M") will be
+interpreted as a letter of the alphabet, not as a Roman numeral.
+Likewise, lists using letters of the alphabet may not begin with
+"I"/"i", since these are recognized as Roman numeral 1.
+
+The second line of each enumerated list item is checked for validity.
+This is to prevent ordinary paragraphs from being mistakenly
+interpreted as list items, when they happen to begin with text
+identical to enumerators.  For example, this text is parsed as an
+ordinary paragraph::
+
+    A. Einstein was a really
+    smart dude.
+
+However, ambiguity cannot be avoided if the paragraph consists of only
+one line.  This text is parsed as an enumerated list item::
+
+    A. Einstein was a really smart dude.
+
+If a single-line paragraph begins with text identical to an enumerator
+("A.", "1.", "(b)", "I)", etc.), the first character will have to be
+escaped in order to have the line parsed as an ordinary paragraph::
+
+    \A. Einstein was a really smart dude.
+
+Examples of nested enumerated lists::
+
+    1. Item 1 initial text.
+
+       a) Item 1a.
+       b) Item 1b.
+
+    2. a) Item 2a.
+       b) Item 2b.
+
+Example syntax diagram::
+
+    +-------+----------------------+
+    | "1. " | list item            |
+    +-------| (body elements)+     |
+            +----------------------+
+
+
+Definition Lists
+----------------
+
+Doctree elements: definition_list_, definition_list_item_, term_,
+classifier_, definition_.
+
+Each definition list item contains a term, optional classifiers, and a
+definition.
+
+* A `term` is a simple one-line word or phrase.  Escape_ a leading hyphen
+  to prevent recognition as an `option list`_ item.
+
+* Optional `classifiers` may follow the term on the same line, each after
+  an inline " : " (space, colon, space).  Inline markup is parsed in the
+  term line before the classifier delimiters are recognized.  A delimiter
+  will only be recognized if it appears outside of any inline markup.
+
+* A `definition` is a block indented relative to the term, and may
+  contain multiple paragraphs and other body elements.  There may be no
+  blank line between a term line and a definition block (this
+  distinguishes definition lists from `block quotes`_). Blank lines are
+  required before the first and after the last definition list item, but
+  are optional in-between.
+
+Example::
+
+    term 1
+        Definition 1.
+
+    term 2
+        Definition 2, paragraph 1.
+
+        Definition 2, paragraph 2.
+
+    term 3 : classifier
+        Definition 3.
+
+    term 4 : classifier one : classifier two
+        Definition 4.
+
+    \-term 5
+        Without escaping, this would be an option list item.
+
+A definition list may be used in various ways, including:
+
+- As a dictionary or glossary.  The term is the word itself, a
+  classifier may be used to indicate the usage of the term (noun,
+  verb, etc.), and the definition follows.
+
+- To describe program variables.  The term is the variable name, a
+  classifier may be used to indicate the type of the variable (string,
+  integer, etc.), and the definition describes the variable's use in
+  the program.  This usage of definition lists supports the classifier
+  syntax of Grouch_, a system for describing and enforcing a Python
+  object schema.
+
+Syntax diagram::
+
+    +----------------------------+
+    | term [ " : " classifier ]* |
+    +--+-------------------------+--+
+       | definition                 |
+       | (body elements)+           |
+       +----------------------------+
+
+
+Field Lists
+-----------
+
+Doctree elements: field_list_, field_, field_name_, field_body_.
+
+Field lists are used as part of an extension syntax, such as options
+for directives_, or database-like records meant for further
+processing.  They may also be used for two-column table-like
+structures resembling database records (label & data pairs).
+Applications of reStructuredText may recognize field names and
+transform fields or field bodies in certain contexts.  For examples,
+see `Bibliographic Fields`_ below, or the "image_" and "meta_"
+directives in `reStructuredText Directives`_.
+
+.. _field names:
+
+Field lists are mappings from *field names* to *field bodies*, modeled on
+RFC822_ headers.  A field name may consist of any characters, but
+colons (":") inside of field names must be backslash-escaped
+when followed by whitespace.\ [#]_
+Inline markup is parsed in field names, but care must be taken when
+using `interpreted text`_ with explicit roles in field names: the role
+must be a suffix to the interpreted text.  Field names are
+case-insensitive when further processed or transformed.  The field
+name, along with a single colon prefix and suffix, together form the
+field marker.  The field marker is followed by whitespace and the
+field body.  The field body may contain multiple body elements,
+indented relative to the field marker.  The first line after the field
+name marker determines the indentation of the field body.  For
+example::
+
+    :Date: 2001-08-16
+    :Version: 1
+    :Authors: - Me
+              - Myself
+              - I
+    :Indentation: Since the field marker may be quite long, the second
+       and subsequent lines of the field body do not have to line up
+       with the first line, but they must be indented relative to the
+       field name marker, and they must line up with each other.
+    :Parameter i: integer
+
+The interpretation of individual words in a multi-word field name is
+up to the application.  The application may specify a syntax for the
+field name.  For example, second and subsequent words may be treated
+as "arguments", quoted phrases may be treated as a single argument,
+and direct support for the "name=value" syntax may be added.
+
+Standard RFC822_ headers cannot be used for this construct because
+they are ambiguous.  A word followed by a colon at the beginning of a
+line is common in written text.  However, in well-defined contexts
+such as when a field list invariably occurs at the beginning of a
+document (PEPs and email messages), standard RFC822 headers could be
+used.
+
+Syntax diagram (simplified)::
+
+    +--------------------+----------------------+
+    | ":" field name ":" | field body           |
+    +-------+------------+                      |
+            | (body elements)+                  |
+            +-----------------------------------+
+
+.. [#] Up to Docutils 0.14, field markers were not recognized when
+   containing a colon.
+
+Bibliographic Fields
+````````````````````
+
+Doctree elements: docinfo_, address_, author_, authors_, contact_,
+copyright_, date_, organization_, revision_, status_, topic_,
+version_.
+
+When a field list is the first element in a document
+(after the document title, if there is one) [#]_, it may have its fields
+transformed to document bibliographic data.  This bibliographic data
+corresponds to the front matter of a book, such as the title page and
+copyright page.
+
+.. [#] In addition to the document title and subtitle, also comments_,
+   `substitution definitions`_, `hyperlink targets`_, and "header",
+   "footer", "meta", and "raw" directives_ may be placed before the
+   bibliographic fields.
+
+Certain registered field names (listed below) are recognized and
+transformed to the corresponding doctree elements, most becoming child
+elements of the docinfo_ element.  No ordering is required of these
+fields, although they may be rearranged to fit the document structure,
+as noted.  Unless otherwise indicated below, each of the bibliographic
+elements' field bodies may contain a single paragraph only.  Field
+bodies may be checked for `RCS keywords`_ and cleaned up.  Any
+unrecognized fields will remain as generic fields in the docinfo
+element.
+
+The registered bibliographic field names and their corresponding
+doctree elements are as follows:
+
+  ============= ================
+  Field name    doctree element
+  ============= ================
+  Abstract      topic_
+  Address       address_
+  Author        author_
+  Authors       authors_
+  Contact       contact_
+  Copyright     copyright_
+  Date          date_
+  Dedication    topic_
+  Organization  organization_
+  Revision      revision_
+  Status        status_
+  Version       version_
+  ============= ================
+
+The "Authors" field may contain either: a single paragraph consisting
+of a list of authors, separated by ";" or "," (";" is checked first,
+so "Doe, Jane; Doe, John" will work.); multiple paragraphs (one per
+author); or a bullet list whose elements each contain a single
+paragraph per author. In some languages
+(e.g. Swedish), there is no singular/plural distinction between
+"Author" and "Authors", so only an "Authors" field is provided, and a
+single name is interpreted as an "Author".  If a single name contains
+a comma, end it with a semicolon to disambiguate: ":Authors: Doe,
+Jane;".
+
+The "Address" field is for a multi-line surface mailing address.
+Newlines and whitespace will be preserved.
+
+The "Dedication" and "Abstract" fields may contain arbitrary body
+elements.  Only one of each is allowed.  They become topic elements
+with "Dedication" or "Abstract" titles (or language equivalents)
+immediately following the docinfo element.
+
+This field-name-to-element mapping can be replaced for other
+languages.  See the `DocInfo transform`_ implementation documentation
+for details.
+
+Unregistered/generic fields may contain one or more paragraphs or
+arbitrary body elements.
+The field name is also used as a `"classes" attribute`_ value after being
+converted into a valid identifier form.
+
+
+RCS Keywords
+````````````
+
+`Bibliographic fields`_ recognized by the parser are normally checked
+for RCS [#]_ keywords and cleaned up [#]_.  RCS keywords may be
+entered into source files as "$keyword$", and once stored under RCS,
+CVS [#]_, or SVN [#]_, they are expanded to "$keyword: expansion text $".
+For example, a "Status" field will be transformed to a "status" element::
+
+    :Status: $keyword: expansion text $
+
+.. [#] Revision Control System.
+.. [#] RCS keyword processing can be turned off (unimplemented).
+.. [#] Concurrent Versions System.  CVS uses the same keywords as RCS.
+.. [#] Subversion Versions System. Uses the same keywords as RCS.
+
+Processed, the "status" element's text will become simply "expansion
+text".  The dollar sign delimiters and leading RCS keyword name are
+removed.
+
+The RCS keyword processing only kicks in when the field list is in
+bibliographic context (first non-comment construct in the document,
+after a document title if there is one).
+
+.. _option list:
+
+Option Lists
+------------
+
+Doctree elements: option_list_, option_list_item_, option_group_, option_,
+option_string_, option_argument_, description_.
+
+Option lists map a program's command-line options to descriptions
+documenting them.  For example::
+
+    -a         Output all.
+    -b         Output both (this description is
+               quite long).
+    -c arg     Output just arg.
+    --long     Output all day long.
+
+    -p         This option has two paragraphs in the description.
+               This is the first.
+
+               This is the second.  Blank lines may be omitted between
+               options (as above) or left in (as here and below).
+
+    --very-long-option  A VMS-style option.  Note the adjustment for
+                        the required two spaces.
+
+    --an-even-longer-option
+               The description can also start on the next line.
+
+    -2, --two  This option has two variants.
+
+    -f FILE, --file=FILE  These two options are synonyms; both have
+                          arguments.
+
+    /V         A VMS/DOS-style option.
+
+There are several types of options recognized by reStructuredText:
+
+- Short POSIX options consist of one dash and an option letter.
+- Long POSIX options consist of two dashes and an option word; some
+  systems use a single dash.
+- Old GNU-style "plus" options consist of one plus and an option
+  letter ("plus" options are deprecated now, their use discouraged).
+- DOS/VMS options consist of a slash and an option letter or word.
+
+Please note that both POSIX-style and DOS/VMS-style options may be
+used by DOS or Windows software.  These and other variations are
+sometimes used mixed together.  The names above have been chosen for
+convenience only.
+
+The syntax for short and long POSIX options is based on the syntax
+supported by Python's getopt.py_ module, which implements an option
+parser similar to the `GNU libc getopt_long()`_ function but with some
+restrictions.  There are many variant option systems, and
+reStructuredText option lists do not support all of them.
+
+Although long POSIX and DOS/VMS option words may be allowed to be
+truncated by the operating system or the application when used on the
+command line, reStructuredText option lists do not show or support
+this with any special syntax.  The complete option word should be
+given, supported by notes about truncation if and when applicable.
+
+Options may be followed by an argument placeholder, whose role and
+syntax should be explained in the description text.
+Either a space or an equals sign may be used as a delimiter between long
+options and option argument placeholders;
+short options ("-" or "+" prefix only) use a space or omit the delimiter.
+Option arguments may take one of two forms:
+
+- Begins with a letter (``[a-zA-Z]``) and subsequently consists of
+  letters, numbers, underscores and hyphens (``[a-zA-Z0-9_-]``).
+- Begins with an open-angle-bracket (``<``) and ends with a
+  close-angle-bracket (``>``); any characters except angle brackets
+  are allowed internally.
+
+Multiple option "synonyms" may be listed, sharing a single
+description.  They must be separated by comma-space.
+
+There must be at least two spaces between the option(s) and the
+description (which can also start on the next line).  The description
+may contain multiple body elements.
+The first line after the option marker determines the indentation of the
+description.  As with other types of lists, blank lines are required
+before the first option list item and after the last, but are optional
+between option entries.
+
+Syntax diagram (simplified)::
+
+    +----------------------------+-------------+
+    | option [" " argument] "  " | description |
+    +-------+--------------------+             |
+            | (body elements)+                 |
+            +----------------------------------+
+
+
+Literal Blocks
+--------------
+
+Doctree element: literal_block_.
+
+A paragraph consisting of two colons ("::") signifies that the
+following text block(s) comprise a literal block.  The literal block
+must either be indented or quoted (see below).  No markup processing
+is done within a literal block.  It is left as-is, and is typically
+rendered in a monospaced typeface::
+
+    This is a typical paragraph.  An indented literal block follows.
+
+    ::
+
+        for a in [5,4,3,2,1]:   # this is program code, shown as-is
+            print a
+        print "it's..."
+        # a literal block continues until the indentation ends
+
+    This text has returned to the indentation of the first paragraph,
+    is outside of the literal block, and is therefore treated as an
+    ordinary paragraph.
+
+The paragraph containing only "::" will be completely removed from the
+output; no empty paragraph will remain.
+
+As a convenience, the "::" is recognized at the end of any paragraph.
+If immediately preceded by whitespace, both colons will be removed
+from the output (this is the "partially minimized" form).  When text
+immediately precedes the "::", *one* colon will be removed from the
+output, leaving only one colon visible (i.e., "::" will be replaced by
+":"; this is the "fully minimized" form).
+
+In other words, these are all equivalent (please pay attention to the
+colons after "Paragraph"):
+
+1. Expanded form::
+
+      Paragraph:
+
+      ::
+
+          Literal block
+
+2. Partially minimized form::
+
+      Paragraph: ::
+
+          Literal block
+
+3. Fully minimized form::
+
+      Paragraph::
+
+          Literal block
+
+All whitespace (including line breaks, but excluding minimum
+indentation for indented literal blocks) is preserved.  Blank lines
+are required before and after a literal block, but these blank lines
+are not included as part of the literal block.
+
+
+Indented Literal Blocks
+```````````````````````
+
+Indented literal blocks are indicated by indentation relative to the
+surrounding text (leading whitespace on each line).  The minimum
+indentation will be removed from each line of an indented literal
+block.  The literal block need not be contiguous; blank lines are
+allowed between sections of indented text.  The literal block ends
+with the end of the indentation.
+
+Syntax diagram::
+
+    +------------------------------+
+    | paragraph                    |
+    | (ends with "::")             |
+    +------------------------------+
+       +---------------------------+
+       | indented literal block    |
+       +---------------------------+
+
+
+Quoted Literal Blocks
+`````````````````````
+
+Quoted literal blocks are unindented contiguous blocks of text where
+each line begins with the same non-alphanumeric printable 7-bit ASCII
+character [#]_.  A blank line ends a quoted literal block.  The
+quoting characters are preserved in the processed document.
+
+.. [#]
+   The following are all valid quoting characters::
+
+       ! " # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \ ] ^ _ ` { | } ~
+
+   Note that these are the same characters as are valid for title
+   adornment of sections_.
+
+Possible uses include literate programming in Haskell and email
+quoting::
+
+    John Doe wrote::
+
+    >> Great idea!
+    >
+    > Why didn't I think of that?
+
+    You just did!  ;-)
+
+Syntax diagram::
+
+    +------------------------------+
+    | paragraph                    |
+    | (ends with "::")             |
+    +------------------------------+
+    +------------------------------+
+    | ">" per-line-quoted          |
+    | ">" contiguous literal block |
+    +------------------------------+
+
+
+Line Blocks
+-----------
+
+Doctree elements: line_block_, line_.  (New in Docutils 0.3.5.)
+
+Line blocks are useful for address blocks, verse (poetry, song
+lyrics), and unadorned lists, where the structure of lines is
+significant.  Line blocks are groups of lines beginning with vertical
+bar ("|") prefixes.  Each vertical bar prefix indicates a new line, so
+line breaks are preserved.  Initial indents are also significant,
+resulting in a nested structure.  Inline markup is supported.
+Continuation lines are wrapped portions of long lines; they begin with
+a space in place of the vertical bar.  The left edge of a continuation
+line must be indented, but need not be aligned with the left edge of
+the text above it.  A line block ends with a blank line.
+
+This example illustrates continuation lines::
+
+    | Lend us a couple of bob till Thursday.
+    | I'm absolutely skint.
+    | But I'm expecting a postal order and I can pay you back
+      as soon as it comes.
+    | Love, Ewan.
+
+This example illustrates the nesting of line blocks, indicated by the
+initial indentation of new lines::
+
+    Take it away, Eric the Orchestra Leader!
+
+        | A one, two, a one two three four
+        |
+        | Half a bee, philosophically,
+        |     must, *ipso facto*, half not be.
+        | But half the bee has got to be,
+        |     *vis a vis* its entity.  D'you see?
+        |
+        | But can a bee be said to be
+        |     or not to be an entire bee,
+        |         when half the bee is not a bee,
+        |             due to some ancient injury?
+        |
+        | Singing...
+
+Syntax diagram::
+
+    +------+-----------------------+
+    | "| " | line                  |
+    +------| continuation line     |
+           +-----------------------+
+
+
+Block Quotes
+------------
+
+Doctree elements: block_quote_, attribution_.
+
+A text block that is indented relative to the preceding text, without
+preceding markup indicating it to be a literal block or other content,
+is a block quote.  All markup processing (for body elements and inline
+markup) continues within the block quote::
+
+    This is an ordinary paragraph, introducing a block quote.
+
+        "It is my business to know things.  That is my trade."
+
+        -- Sherlock Holmes
+
+A block quote may end with an attribution: a text block beginning with
+``--``, ``---``, or a true em-dash, flush left within the block quote.  If
+the attribution consists of multiple lines, the left edges of the
+second and subsequent lines must align.
+
+Multiple block quotes may occur consecutively if terminated with
+attributions.
+
+    Unindented paragraph.
+
+        Block quote 1.
+
+        -- Attribution 1
+
+        Block quote 2.
+
+`Empty comments`_ may be used to explicitly terminate preceding
+constructs that would otherwise consume a block quote::
+
+    * List item.
+
+    ..
+
+        Block quote 3.
+
+Empty comments may also be used to separate block quotes::
+
+        Block quote 4.
+
+    ..
+
+        Block quote 5.
+
+Blank lines are required before and after a block quote, but these
+blank lines are not included as part of the block quote.
+
+Syntax diagram::
+
+    +------------------------------+
+    | (current level of            |
+    | indentation)                 |
+    +------------------------------+
+       +---------------------------+
+       | block quote               |
+       | (body elements)+          |
+       |                           |
+       | -- attribution text       |
+       |    (optional)             |
+       +---------------------------+
+
+
+Doctest Blocks
+--------------
+
+Doctree element: doctest_block_.
+
+Doctest blocks are interactive Python sessions cut-and-pasted into
+docstrings.  They are meant to illustrate usage by example, and
+provide an elegant and powerful testing environment via the `doctest
+module`_ in the Python standard library.
+
+Doctest blocks are text blocks which begin with ``">>> "``, the Python
+interactive interpreter main prompt, and end with a blank line.
+Doctest blocks are treated as a special case of literal blocks,
+without requiring the literal block syntax.  If both are present, the
+literal block syntax takes priority over Doctest block syntax::
+
+    This is an ordinary paragraph.
+
+    >>> print 'this is a Doctest block'
+    this is a Doctest block
+
+    The following is a literal block::
+
+        >>> This is not recognized as a doctest block by
+        reStructuredText.  It *will* be recognized by the doctest
+        module, though!
+
+Indentation is not required for doctest blocks.
+
+
+Tables
+------
+
+Doctree elements: table_, tgroup_, colspec_, thead_, tbody_, row_, entry_.
+
+ReStructuredText provides two syntax variants for delineating table
+cells: `Grid Tables`_ and `Simple Tables`_. Tables are also generated by
+the `CSV Table`_ and `List Table`_ directives. The `table
+directive`_ is used to add a table title or specify options.
+
+As with other body elements, blank lines are required before and after
+tables.  Tables' left edges should align with the left edge of
+preceding text blocks; if indented, the table is considered to be part
+of a block quote.
+
+Once isolated, each table cell is treated as a miniature document; the
+top and bottom cell boundaries act as delimiting blank lines.  Each
+cell contains zero or more body elements.  Cell contents may include
+left and/or right margins, which are removed before processing.
+
+
+Grid Tables
+```````````
+
+Grid tables provide a complete table representation via grid-like
+"ASCII art".  Grid tables allow arbitrary cell contents (body
+elements), and both row and column spans.  However, grid tables can be
+cumbersome to produce, especially for simple data sets.  The `Emacs
+table mode`_ is a tool that allows easy editing of grid tables, in
+Emacs.  See `Simple Tables`_ for a simpler (but limited)
+representation.
+
+Grid tables are described with a visual grid made up of the characters
+"-", "=", "|", and "+".  The hyphen ("-") is used for horizontal lines
+(row separators).  The equals sign ("=") may be used to separate
+optional header rows from the table body (not supported by the `Emacs
+table mode`_).  The vertical bar ("|") is used for vertical lines
+(column separators).  The plus sign ("+") is used for intersections of
+horizontal and vertical lines.  Example::
+
+    +------------------------+------------+----------+----------+
+    | Header row, column 1   | Header 2   | Header 3 | Header 4 |
+    | (header rows optional) |            |          |          |
+    +========================+============+==========+==========+
+    | body row 1, column 1   | column 2   | column 3 | column 4 |
+    +------------------------+------------+----------+----------+
+    | body row 2             | Cells may span columns.          |
+    +------------------------+------------+---------------------+
+    | body row 3             | Cells may  | - Table cells       |
+    +------------------------+ span rows. | - contain           |
+    | body row 4             |            | - body elements.    |
+    +------------------------+------------+---------------------+
+
+Some care must be taken with grid tables to avoid undesired
+interactions with cell text in rare cases.  For example, the following
+table contains a cell in row 2 spanning from column 2 to column 4::
+
+    +--------------+----------+-----------+-----------+
+    | row 1, col 1 | column 2 | column 3  | column 4  |
+    +--------------+----------+-----------+-----------+
+    | row 2        |                                  |
+    +--------------+----------+-----------+-----------+
+    | row 3        |          |           |           |
+    +--------------+----------+-----------+-----------+
+
+If a vertical bar is used in the text of that cell, it could have
+unintended effects if accidentally aligned with column boundaries::
+
+    +--------------+----------+-----------+-----------+
+    | row 1, col 1 | column 2 | column 3  | column 4  |
+    +--------------+----------+-----------+-----------+
+    | row 2        | Use the command ``ls | more``.   |
+    +--------------+----------+-----------+-----------+
+    | row 3        |          |           |           |
+    +--------------+----------+-----------+-----------+
+
+Several solutions are possible.  All that is needed is to break the
+continuity of the cell outline rectangle.  One possibility is to shift
+the text by adding an extra space before::
+
+    +--------------+----------+-----------+-----------+
+    | row 1, col 1 | column 2 | column 3  | column 4  |
+    +--------------+----------+-----------+-----------+
+    | row 2        |  Use the command ``ls | more``.  |
+    +--------------+----------+-----------+-----------+
+    | row 3        |          |           |           |
+    +--------------+----------+-----------+-----------+
+
+Another possibility is to add an extra line to row 2::
+
+    +--------------+----------+-----------+-----------+
+    | row 1, col 1 | column 2 | column 3  | column 4  |
+    +--------------+----------+-----------+-----------+
+    | row 2        | Use the command ``ls | more``.   |
+    |              |                                  |
+    +--------------+----------+-----------+-----------+
+    | row 3        |          |           |           |
+    +--------------+----------+-----------+-----------+
+
+
+Simple Tables
+`````````````
+
+Simple tables provide a compact and easy to type but limited
+row-oriented table representation for simple data sets.  Cell contents
+are typically single paragraphs, although arbitrary body elements may
+be represented in most cells.  Simple tables allow multi-line rows (in
+all but the first column) and column spans, but not row spans.  See
+`Grid Tables`_ above for a complete table representation.
+
+Simple tables are described with horizontal borders made up of "=" and
+"-" characters.  The equals sign ("=") is used for top and bottom
+table borders, and to separate optional header rows from the table
+body.  The hyphen ("-") is used to indicate column spans in a single
+row by underlining the joined columns, and may optionally be used to
+explicitly and/or visually separate rows.
+
+A simple table begins with a top border of equals signs with one or
+more spaces at each column boundary (two or more spaces recommended).
+Regardless of spans, the top border *must* fully describe all table
+columns.  There must be at least two columns in the table (to
+differentiate it from section headers).  The top border may be
+followed by header rows, and the last of the optional header rows is
+underlined with '=', again with spaces at column boundaries.  There
+may not be a blank line below the header row separator; it would be
+interpreted as the bottom border of the table.  The bottom boundary of
+the table consists of '=' underlines, also with spaces at column
+boundaries.  For example, here is a truth table, a three-column table
+with one header row and four body rows::
+
+    =====  =====  =======
+      A      B    A and B
+    =====  =====  =======
+    False  False  False
+    True   False  False
+    False  True   False
+    True   True   True
+    =====  =====  =======
+
+Underlines of '-' may be used to indicate column spans by "filling in"
+column margins to join adjacent columns.  Column span underlines must
+be complete (they must cover all columns) and align with established
+column boundaries.  Text lines containing column span underlines may
+not contain any other text.  A column span underline applies only to
+one row immediately above it.  For example, here is a table with a
+column span in the header::
+
+    =====  =====  ======
+       Inputs     Output
+    ------------  ------
+      A      B    A or B
+    =====  =====  ======
+    False  False  False
+    True   False  True
+    False  True   True
+    True   True   True
+    =====  =====  ======
+
+Each line of text must contain spaces at column boundaries, except
+where cells have been joined by column spans.  Each line of text
+starts a new row, except when there is a blank cell in the first
+column.  In that case, that line of text is parsed as a continuation
+line.  For this reason, cells in the first column of new rows (*not*
+continuation lines) *must* contain some text; blank cells would lead
+to a misinterpretation (but see the tip below).  Also, this mechanism
+limits cells in the first column to only one line of text.  Use `grid
+tables`_ if this limitation is unacceptable.
+
+.. Tip::
+
+   To start a new row in a simple table without text in the first
+   column in the processed output, use one of these:
+
+   * an empty comment (".."), which may be omitted from the processed
+     output (see Comments_ below)
+
+   * a backslash escape ("``\``") followed by a space (see `Escaping
+     Mechanism`_ above)
+
+Underlines of '-' may also be used to visually separate rows, even if
+there are no column spans.  This is especially useful in long tables,
+where rows are many lines long.
+
+Blank lines are permitted within simple tables.  Their interpretation
+depends on the context.  Blank lines *between* rows are ignored.
+Blank lines *within* multi-line rows may separate paragraphs or other
+body elements within cells.
+
+The rightmost column is unbounded; text may continue past the edge of
+the table (as indicated by the table borders).  However, it is
+recommended that borders be made long enough to contain the entire
+text.
+
+The following example illustrates continuation lines (row 2 consists
+of two lines of text, and four lines for row 3), a blank line
+separating paragraphs (row 3, column 2), text extending past the right
+edge of the table, and a new row which will have no text in the first
+column in the processed output (row 4)::
+
+    =====  =====
+    col 1  col 2
+    =====  =====
+    1      Second column of row 1.
+    2      Second column of row 2.
+           Second line of paragraph.
+    3      - Second column of row 3.
+
+           - Second item in bullet
+             list (row 3, column 2).
+    \      Row 4; column 1 will be empty.
+    =====  =====
+
+
+Explicit Markup Blocks
+----------------------
+
+The explicit markup syntax is used for footnotes_, citations_,
+`hyperlink targets`_, directives_, `substitution definitions`_,
+and comments_.
+
+An explicit markup block is a text block:
+
+- whose first line begins with ".." followed by whitespace (the
+  "explicit markup start"),
+- whose second and subsequent lines (if any) are indented relative to
+  the first, and
+- which ends before an unindented line.
+
+Explicit markup blocks are analogous to field list items. The
+maximum common indentation is always removed from the second and
+subsequent lines of the block body.  Therefore, if the first construct
+fits in one line and the indentation of the first and second
+constructs should differ, the first construct should not begin on the
+same line as the explicit markup start.
+
+Blank lines are required between explicit markup blocks and other
+elements, but are optional between explicit markup blocks where
+unambiguous.
+
+
+Footnotes
+`````````
+
+See also: `Footnote References`_.
+
+Doctree elements: footnote_, label_.
+
+Configuration settings:
+`footnote_references <footnote_references setting_>`_.
+
+.. _footnote_references setting:
+   ../../user/config.html#footnote-references
+
+Each footnote consists of an explicit markup start (".. "), a left
+square bracket, the footnote label, a right square bracket, and
+whitespace, followed by indented body elements.  A footnote label can
+be:
+
+- a whole decimal number consisting of one or more digits,
+
+- a single "#" (denoting `auto-numbered footnotes`_),
+
+- a "#" followed by a simple reference name (an `autonumber label`_),
+  or
+
+- a single "*" (denoting `auto-symbol footnotes`_).
+
+The footnote content (body elements) must be consistently indented
+and left-aligned.  The first body element within a
+footnote may often begin on the same line as the footnote label.
+However, if the first element fits on one line and the indentation of
+the remaining elements differ, the first element must begin on the
+line after the footnote label.  Otherwise, the difference in
+indentation will not be detected.
+
+Footnotes may occur anywhere in the document, not only at the end.
+Where and how they appear in the processed output depends on the
+processing system.
+
+Here is a manually numbered footnote::
+
+    .. [1] Body elements go here.
+
+Each footnote automatically generates a hyperlink target pointing to
+itself.  The text of the hyperlink target name is the same as that of
+the footnote label.  `Auto-numbered footnotes`_ generate a number as
+their footnote label and reference name.  See `Implicit Hyperlink
+Targets`_ for a complete description of the mechanism.
+
+Syntax diagram::
+
+    +-------+-------------------------+
+    | ".. " | "[" label "]" footnote  |
+    +-------+                         |
+            | (body elements)+        |
+            +-------------------------+
+
+
+Auto-Numbered Footnotes
+.......................
+
+A number sign ("#") may be used as the first character of a footnote
+label to request automatic numbering of the footnote or footnote
+reference.
+
+The first footnote to request automatic numbering is assigned the
+label "1", the second is assigned the label "2", and so on (assuming
+there are no manually numbered footnotes present; see `Mixed Manual
+and Auto-Numbered Footnotes`_ below).  A footnote which has
+automatically received a label "1" generates an implicit hyperlink
+target with name "1", just as if the label was explicitly specified.
+
+.. _autonumber label: `autonumber labels`_
+
+A footnote may specify a label explicitly while at the same time
+requesting automatic numbering: ``[#label]``.  These labels are called
+_`autonumber labels`.  Autonumber labels do two things:
+
+- On the footnote itself, they generate a hyperlink target whose name
+  is the autonumber label (doesn't include the "#").
+
+- They allow an automatically numbered footnote to be referred to more
+  than once, as a footnote reference or hyperlink reference.  For
+  example::
+
+      If [#note]_ is the first footnote reference, it will show up as
+      "[1]".  We can refer to it again as [#note]_ and again see
+      "[1]".  We can also refer to it as note_ (an ordinary internal
+      hyperlink reference).
+
+      .. [#note] This is the footnote labeled "note".
+
+The numbering is determined by the order of the footnotes, not by the
+order of the references.  For footnote references without autonumber
+labels (``[#]_``), the footnotes and footnote references must be in
+the same relative order but need not alternate in lock-step.  For
+example::
+
+    [#]_ is a reference to footnote 1, and [#]_ is a reference to
+    footnote 2.
+
+    .. [#] This is footnote 1.
+    .. [#] This is footnote 2.
+    .. [#] This is footnote 3.
+
+    [#]_ is a reference to footnote 3.
+
+Special care must be taken if footnotes themselves contain
+auto-numbered footnote references, or if multiple references are made
+in close proximity.  Footnotes and references are noted in the order
+they are encountered in the document, which is not necessarily the
+same as the order in which a person would read them.
+
+
+Auto-Symbol Footnotes
+.....................
+
+An asterisk ("*") may be used for footnote labels to request automatic
+symbol generation for footnotes and footnote references.  The asterisk
+may be the only character in the label.  For example::
+
+    Here is a symbolic footnote reference: [*]_.
+
+    .. [*] This is the footnote.
+
+A transform will insert symbols as labels into corresponding footnotes
+and footnote references.  The number of references must be equal to
+the number of footnotes.  One symbol footnote cannot have multiple
+references.
+
+The standard Docutils system uses the following symbols for footnote
+marks [#]_:
+
+- asterisk/star ("*")
+- dagger (HTML character entity "&dagger;", Unicode U+02020)
+- double dagger ("&Dagger;"/U+02021)
+- section mark ("&sect;"/U+000A7)
+- pilcrow or paragraph mark ("&para;"/U+000B6)
+- number sign ("#")
+- spade suit ("&spades;"/U+02660)
+- heart suit ("&hearts;"/U+02665)
+- diamond suit ("&diams;"/U+02666)
+- club suit ("&clubs;"/U+02663)
+
+.. [#] This list was inspired by the list of symbols for "Note
+   Reference Marks" in The Chicago Manual of Style, 14th edition,
+   section 12.51.  "Parallels" ("||") were given in CMoS instead of
+   the pilcrow.  The last four symbols (the card suits) were added
+   arbitrarily.
+
+If more than ten symbols are required, the same sequence will be
+reused, doubled and then tripled, and so on ("**" etc.).
+
+.. Note:: When using auto-symbol footnotes, the choice of output
+   encoding is important.  Many of the symbols used are not encodable
+   in certain common text encodings such as Latin-1 (ISO 8859-1).  The
+   use of UTF-8 for the output encoding is recommended.  An
+   alternative for HTML and XML output is to use the
+   "xmlcharrefreplace" `output encoding error handler`__.
+
+__ ../../user/config.html#output-encoding-error-handler
+
+
+Mixed Manual and Auto-Numbered Footnotes
+........................................
+
+Manual and automatic footnote numbering may both be used within a
+single document, although the results may not be expected.  Manual
+numbering takes priority.  Only unused footnote numbers are assigned
+to auto-numbered footnotes.  The following example should be
+illustrative::
+
+    [2]_ will be "2" (manually numbered),
+    [#]_ will be "3" (anonymous auto-numbered), and
+    [#label]_ will be "1" (labeled auto-numbered).
+
+    .. [2] This footnote is labeled manually, so its number is fixed.
+
+    .. [#label] This autonumber-labeled footnote will be labeled "1".
+       It is the first auto-numbered footnote and no other footnote
+       with label "1" exists.  The order of the footnotes is used to
+       determine numbering, not the order of the footnote references.
+
+    .. [#] This footnote will be labeled "3".  It is the second
+       auto-numbered footnote, but footnote label "2" is already used.
+
+
+Citations
+`````````
+
+See also: `Citation References`_.
+
+Doctree element: citation_
+
+Citations are identical to footnotes except that they use only
+non-numeric labels such as ``[note]`` or ``[GVR2001]``.  Citation
+labels are simple `reference names`_ (case-insensitive single words
+consisting of alphanumerics plus internal hyphens, underscores, and
+periods; no whitespace).  Citations may be rendered separately and
+differently from footnotes.  For example::
+
+    Here is a citation reference: [CIT2002]_.
+
+    .. [CIT2002] This is the citation.  It's just like a footnote,
+       except the label is textual.
+
+
+.. _hyperlinks:
+
+Hyperlink Targets
+`````````````````
+
+Doctree element: target_.
+
+These are also called _`explicit hyperlink targets`, to differentiate
+them from `implicit hyperlink targets`_ defined below.
+
+Hyperlink targets identify a location within or outside of a document,
+which may be linked to by `hyperlink references`_.
+
+Hyperlink targets may be named or anonymous.  Named hyperlink targets
+consist of an explicit markup start (".. "), an underscore, the
+reference name (no trailing underscore), a colon, whitespace, and a
+link block::
+
+    .. _hyperlink-name: link-block
+
+Reference names are whitespace-neutral and case-insensitive.  See
+`Reference Names`_ for details and examples.
+
+Anonymous hyperlink targets consist of an explicit markup start
+(".. "), two underscores, a colon, whitespace, and a link block; there
+is no reference name::
+
+    .. __: anonymous-hyperlink-target-link-block
+
+An alternate syntax for anonymous hyperlinks consists of two
+underscores, a space, and a link block::
+
+    __ anonymous-hyperlink-target-link-block
+
+See `Anonymous Hyperlinks`_ below.
+
+There are three types of hyperlink targets: internal, external, and
+indirect.
+
+1. _`Internal hyperlink targets` have empty link blocks.  They provide
+   an end point allowing a hyperlink to connect one place to another
+   within a document.  An internal hyperlink target points to the
+   element following the target. [#]_  For example::
+
+       Clicking on this internal hyperlink will take us to the target_
+       below.
+
+       .. _target:
+
+       The hyperlink target above points to this paragraph.
+
+   Internal hyperlink targets may be "chained".  Multiple adjacent
+   internal hyperlink targets all point to the same element::
+
+       .. _target1:
+       .. _target2:
+
+       The targets "target1" and "target2" are synonyms; they both
+       point to this paragraph.
+
+   If the element "pointed to" is an external hyperlink target (with a
+   URI in its link block; see #2 below) the URI from the external
+   hyperlink target is propagated to the internal hyperlink targets;
+   they will all "point to" the same URI.  There is no need to
+   duplicate a URI.  For example, all three of the following hyperlink
+   targets refer to the same URI::
+
+       .. _Python DOC-SIG mailing list archive:
+       .. _archive:
+       .. _Doc-SIG: https://mail.python.org/pipermail/doc-sig/
+
+   An inline form of internal hyperlink target is available; see
+   `Inline Internal Targets`_.
+
+   .. [#] Works also, if the internal hyperlink target is "nested" at the
+      end of an indented text block. This behaviour allows setting targets
+      to individual list items (except the first, as a preceding internal
+      target applies to the list as a whole)::
+
+       * bullet list
+
+         .. _`second item`:
+
+       * second item, with hyperlink target.
+
+
+2. _`External hyperlink targets` have an absolute or relative URI or
+   email address in their link blocks.  For example, take the
+   following input::
+
+       See the Python_ home page for info.
+
+       `Write to me`_ with your questions.
+
+       .. _Python: https://www.python.org
+       .. _Write to me: jdoe@example.com
+
+   After processing into HTML, the hyperlinks might be expressed as::
+
+       See the <a href="https://www.python.org">Python</a> home page
+       for info.
+
+       <a href="mailto:jdoe@example.com">Write to me</a> with your
+       questions.
+
+   An external hyperlink's URI may begin on the same line as the
+   explicit markup start and target name, or it may begin in an
+   indented text block immediately following, with no intervening
+   blank lines.  If there are multiple lines in the link block, they
+   are concatenated.  Any unescaped whitespace is removed (whitespace is
+   permitted to allow for line wrapping).  The following external
+   hyperlink targets are equivalent::
+
+       .. _one-liner: https://docutils.sourceforge.io/rst.html
+
+       .. _starts-on-this-line: https://
+          docutils.sourceforge.net/rst.html
+
+       .. _entirely-below:
+          https://docutils.
+          sourceforge.net/rst.html
+
+   Escaped whitespace is preserved as intentional spaces, e.g.::
+
+       .. _reference: ../local\ path\ with\ spaces.html
+
+   If an external hyperlink target's URI contains an underscore as its
+   last character, it must be escaped to avoid being mistaken for an
+   indirect hyperlink target::
+
+       This link_ refers to a file called ``underscore_``.
+
+       .. _link: underscore\_
+
+   It is possible (although not generally recommended) to include URIs
+   directly within hyperlink references.  See `Embedded URIs and Aliases`_
+   below.
+
+3. _`Indirect hyperlink targets` have a hyperlink reference in their
+   link blocks.  In the following example, target "one" indirectly
+   references whatever target "two" references, and target "two"
+   references target "three", an internal hyperlink target.  In
+   effect, all three reference the same thing::
+
+       .. _one: two_
+       .. _two: three_
+       .. _three:
+
+   Just as with `hyperlink references`_ anywhere else in a document,
+   if a phrase-reference is used in the link block it must be enclosed
+   in backquotes.  As with `external hyperlink targets`_, the link
+   block of an indirect hyperlink target may begin on the same line as
+   the explicit markup start or the next line.  It may also be split
+   over multiple lines, in which case the lines are joined with
+   whitespace before being normalized.
+
+   For example, the following indirect hyperlink targets are
+   equivalent::
+
+       .. _one-liner: `A HYPERLINK`_
+       .. _entirely-below:
+          `a    hyperlink`_
+       .. _split: `A
+          Hyperlink`_
+
+   It is possible to include an alias directly within hyperlink
+   references. See `Embedded URIs and Aliases`_ below.
+
+If the reference name contains any colons, either:
+
+- the phrase must be enclosed in backquotes::
+
+      .. _`FAQTS: Computers: Programming: Languages: Python`:
+         http://python.faqts.com/
+
+- or the colon(s) must be backslash-escaped in the link target::
+
+      .. _Chapter One\: "Tadpole Days":
+
+      It's not easy being green...
+
+See `Implicit Hyperlink Targets`_ below for the resolution of
+duplicate reference names.
+
+Syntax diagram::
+
+    +-------+----------------------+
+    | ".. " | "_" name ":" link    |
+    +-------+ block                |
+            |                      |
+            +----------------------+
+
+
+Anonymous Hyperlinks
+....................
+
+The `World Wide Web Consortium`_ recommends in its `HTML Techniques
+for Web Content Accessibility Guidelines`_ that authors should
+"clearly identify the target of each link."  Hyperlink references
+should be as verbose as possible, but duplicating a verbose hyperlink
+name in the target is onerous and error-prone.  Anonymous hyperlinks
+are designed to allow convenient verbose hyperlink references, and are
+analogous to `Auto-Numbered Footnotes`_.  They are particularly useful
+in short or one-off documents.  However, this feature is easily abused
+and can result in unreadable plaintext and/or unmaintainable
+documents.  Caution is advised.
+
+Anonymous `hyperlink references`_ are specified with two underscores
+instead of one::
+
+    See `the web site of my favorite programming language`__.
+
+Anonymous targets begin with ".. __:"; no reference name is required
+or allowed::
+
+    .. __: https://www.python.org
+
+As a convenient alternative, anonymous targets may begin with "__"
+only::
+
+    __ https://www.python.org
+
+The reference name of the reference is not used to match the reference
+to its target.  Instead, the order of anonymous hyperlink references
+and targets within the document is significant: the first anonymous
+reference will link to the first anonymous target.  The number of
+anonymous hyperlink references in a document must match the number of
+anonymous targets.  For readability, it is recommended that targets be
+kept close to references.  Take care when editing text containing
+anonymous references; adding, removing, and rearranging references
+require attention to the order of corresponding targets.
+
+
+Directives
+``````````
+
+Doctree elements: depend on the directive.
+
+Directives are an extension mechanism for reStructuredText, a way of
+adding support for new constructs without adding new primary syntax
+(directives may support additional syntax locally).  All standard
+directives (those implemented and registered in the reference
+reStructuredText parser) are described in the `reStructuredText
+Directives`_ document, and are always available.  Any other directives
+are domain-specific, and may require special action to make them
+available when processing the document.
+
+For example, here's how an image_ may be placed::
+
+    .. image:: mylogo.jpeg
+
+A figure_ (a graphic with a caption) may placed like this::
+
+    .. figure:: larch.png
+
+       The larch.
+
+An admonition_ (note, caution, etc.) contains other body elements::
+
+    .. note:: This is a paragraph
+
+       - Here is a bullet list.
+
+Directives are indicated by an explicit markup start (".. ") followed
+by the directive type, two colons, and whitespace (together called the
+"directive marker").  Directive types are case-insensitive single
+words (alphanumerics plus isolated internal hyphens, underscores,
+plus signs, colons, and periods; no whitespace).  Two colons are used
+after the directive type for these reasons:
+
+- Two colons are distinctive, and unlikely to be used in common text.
+
+- Two colons avoids clashes with common comment text like::
+
+      .. Danger: modify at your own risk!
+
+- If an implementation of reStructuredText does not recognize a
+  directive (i.e., the directive-handler is not installed), a level-3
+  (error) system message is generated, and the entire directive block
+  (including the directive itself) will be included as a literal
+  block.  Thus "::" is a natural choice.
+
+The directive block consists of any text on the first line of the
+directive after the directive marker, and any subsequent indented
+text.  The interpretation of the directive block is up to the
+directive code.  There are three logical parts to the directive block:
+
+1. Directive arguments.
+2. Directive options.
+3. Directive content.
+
+Individual directives can employ any combination of these parts.
+Directive arguments can be filesystem paths, URLs, title text, etc.
+Directive options are indicated using `field lists`_; the field names
+and contents are directive-specific.  Arguments and options must form
+a contiguous block beginning on the first or second line of the
+directive; a blank line indicates the beginning of the directive
+content block.  If either arguments and/or options are employed by the
+directive, a blank line must separate them from the directive content.
+The "figure" directive employs all three parts::
+
+    .. figure:: larch.png
+       :scale: 50
+
+       The larch.
+
+Simple directives may not require any content.  If a directive that
+does not employ a content block is followed by indented text anyway,
+it is an error.  If a block quote should immediately follow a
+directive, use an empty comment in-between (see Comments_ below).
+
+Actions taken in response to directives and the interpretation of text
+in the directive content block or subsequent text block(s) are
+directive-dependent.  See `reStructuredText Directives`_ for details.
+
+Directives are meant for the arbitrary processing of their contents,
+which can be transformed into something possibly unrelated to the
+original text.  It may also be possible for directives to be used as
+pragmas, to modify the behavior of the parser, such as to experiment
+with alternate syntax.  There is no parser support for this
+functionality at present; if a reasonable need for pragma directives
+is found, they may be supported.
+
+Directives do not generate "directive" elements; they are a *parser
+construct* only, and have no intrinsic meaning outside of
+reStructuredText.  Instead, the parser will transform recognized
+directives into (possibly specialized) document elements.  Unknown
+directives will trigger level-3 (error) system messages.
+
+Syntax diagram::
+
+    +-------+-------------------------------+
+    | ".. " | directive type "::" directive |
+    +-------+ block                         |
+            |                               |
+            +-------------------------------+
+
+
+Substitution Definitions
+````````````````````````
+
+Doctree element: substitution_definition_.
+
+Substitution definitions are indicated by an explicit markup start
+(".. ") followed by a vertical bar, the substitution text, another
+vertical bar, whitespace, and the definition block.  Substitution text
+may not begin or end with whitespace.  A substitution definition block
+contains an embedded inline-compatible directive (without the leading
+".. "), such as "image_" or "replace_".  For example::
+
+    The |biohazard| symbol must be used on containers used to
+    dispose of medical waste.
+
+    .. |biohazard| image:: biohazard.png
+
+It is an error for a substitution definition block to directly or
+indirectly contain a circular substitution reference.
+
+`Substitution references`_ are replaced in-line by the processed
+contents of the corresponding definition (linked by matching
+substitution text).  Matches are case-sensitive but forgiving; if no
+exact match is found, a case-insensitive comparison is attempted.
+
+Substitution definitions allow the power and flexibility of
+block-level directives_ to be shared by inline text.  They are a way
+to include arbitrarily complex inline structures within text, while
+keeping the details out of the flow of text.  They are the equivalent
+of SGML/XML's named entities or programming language macros.
+
+Without the substitution mechanism, every time someone wants an
+application-specific new inline structure, they would have to petition
+for a syntax change.  In combination with existing directive syntax,
+any inline structure can be coded without new syntax (except possibly
+a new directive).
+
+Syntax diagram::
+
+    +-------+-----------------------------------------------------+
+    | ".. " | "|" substitution text "| " directive type "::" data |
+    +-------+ directive block                                     |
+            |                                                     |
+            +-----------------------------------------------------+
+
+Following are some use cases for the substitution mechanism.  Please
+note that most of the embedded directives shown are examples only and
+have not been implemented.
+
+Objects
+    Substitution references may be used to associate ambiguous text
+    with a unique object identifier.
+
+    For example, many sites may wish to implement an inline "user"
+    directive::
+
+        |Michael| and |Jon| are our widget-wranglers.
+
+        .. |Michael| user:: mjones
+        .. |Jon|     user:: jhl
+
+    Depending on the needs of the site, this may be used to index the
+    document for later searching, to hyperlink the inline text in
+    various ways (mailto, homepage, mouseover Javascript with profile
+    and contact information, etc.), or to customize presentation of
+    the text (include username in the inline text, include an icon
+    image with a link next to the text, make the text bold or a
+    different color, etc.).
+
+    The same approach can be used in documents which frequently refer
+    to a particular type of objects with unique identifiers but
+    ambiguous common names.  Movies, albums, books, photos, court
+    cases, and laws are possible.  For example::
+
+        |The Transparent Society| offers a fascinating alternate view
+        on privacy issues.
+
+        .. |The Transparent Society| book:: isbn=0738201448
+
+    Classes or functions, in contexts where the module or class names
+    are unclear and/or interpreted text cannot be used, are another
+    possibility::
+
+        4XSLT has the convenience method |runString|, so you don't
+        have to mess with DOM objects if all you want is the
+        transformed output.
+
+        .. |runString| function:: module=xml.xslt class=Processor
+
+Images
+    Images are a common use for substitution references::
+
+        West led the |H| 3, covered by dummy's |H| Q, East's |H| K,
+        and trumped in hand with the |S| 2.
+
+        .. |H| image:: /images/heart.png
+           :height: 11
+           :width: 11
+        .. |S| image:: /images/spade.png
+           :height: 11
+           :width: 11
+
+        * |Red light| means stop.
+        * |Green light| means go.
+        * |Yellow light| means go really fast.
+
+        .. |Red light|    image:: red_light.png
+        .. |Green light|  image:: green_light.png
+        .. |Yellow light| image:: yellow_light.png
+
+        |-><-| is the official symbol of POEE_.
+
+        .. |-><-| image:: discord.png
+        .. _POEE: http://www.poee.org/
+
+    The "image_" directive has been implemented.
+
+Styles [#]_
+    Substitution references may be used to associate inline text with
+    an externally defined presentation style::
+
+        Even |the text in Texas| is big.
+
+        .. |the text in Texas| style:: big
+
+    The style name may be meaningful in the context of some particular
+    output format (CSS class name for HTML output, LaTeX style name
+    for LaTeX, etc), or may be ignored for other output formats (such
+    as plaintext).
+
+    .. @@@ This needs to be rethought & rewritten or removed:
+
+       Interpreted text is unsuitable for this purpose because the set
+       of style names cannot be predefined - it is the domain of the
+       content author, not the author of the parser and output
+       formatter - and there is no way to associate a style name
+       argument with an interpreted text style role.  Also, it may be
+       desirable to use the same mechanism for styling blocks::
+
+           .. style:: motto
+              At Bob's Underwear Shop, we'll do anything to get in
+              your pants.
+
+           .. style:: disclaimer
+              All rights reversed.  Reprint what you like.
+
+    .. [#] There may be sufficient need for a "style" mechanism to
+       warrant simpler syntax such as an extension to the interpreted
+       text role syntax.  The substitution mechanism is cumbersome for
+       simple text styling.
+
+Templates
+    Inline markup may be used for later processing by a template
+    engine.  For example, a Zope_ author might write::
+
+        Welcome back, |name|!
+
+        .. |name| tal:: replace user/getUserName
+
+    After processing, this ZPT output would result::
+
+        Welcome back,
+        <span tal:replace="user/getUserName">name</span>!
+
+    Zope would then transform this to something like "Welcome back,
+    David!" during a session with an actual user.
+
+Replacement text
+    The substitution mechanism may be used for simple macro
+    substitution.  This may be appropriate when the replacement text
+    is repeated many times throughout one or more documents,
+    especially if it may need to change later.  A short example is
+    unavoidably contrived::
+
+        |RST|_ is a little annoying to type over and over, especially
+        when writing about |RST| itself, and spelling out the
+        bicapitalized word |RST| every time isn't really necessary for
+        |RST| source readability.
+
+        .. |RST| replace:: reStructuredText
+        .. _RST: https://docutils.sourceforge.io/rst.html
+
+    Note the trailing underscore in the first use of a substitution
+    reference.  This indicates a reference to the corresponding
+    hyperlink target.
+
+    Substitution is also appropriate when the replacement text cannot
+    be represented using other inline constructs, or is obtrusively
+    long::
+
+        But still, that's nothing compared to a name like
+        |j2ee-cas|__.
+
+        .. |j2ee-cas| replace::
+           the Java `TM`:super: 2 Platform, Enterprise Edition Client
+           Access Services
+        __ http://developer.java.sun.com/developer/earlyAccess/
+           j2eecas/
+
+    The "replace_" directive has been implemented.
+
+
+Comments
+````````
+
+Doctree element: comment_.
+
+`Explicit markup blocks`_ that are not recognized as citations_,
+directives_, footnotes_, `hyperlink targets`_, or `substitution
+definitions`_ will be processed as a comment element. Arbitrary
+indented text may be used on the lines following the explicit markup
+start. To ensure that none of the other explicit markup constructs is
+recognized, leave the ".." on a line by itself::
+
+    .. This is a comment
+    ..
+       _so: is this!
+    ..
+       [and] this!
+    ..
+       this:: too!
+    ..
+       |even| this:: !
+
+    .. [this] however, is a citation.
+
+Apart from removing the maximum common indentation, no further
+processing is done on the content; a comment contains a single "text
+blob".  Depending on the output formatter, comments may be removed
+from the processed output.
+
+Syntax diagram::
+
+    +-------+----------------------+
+    | ".. " | comment              |
+    +-------+ block                |
+            |                      |
+            +----------------------+
+
+Empty Comments
+..............
+
+An explicit markup start followed by a blank line and nothing else
+(apart from whitespace) is an "_`empty comment`".  It serves to
+terminate a preceding construct, and does **not** consume any indented
+text following.  To have a block quote follow a list or any indented
+construct, insert an unindented empty comment in-between::
+
+    This is
+      a definition list.
+
+    ..
+
+      This is a block quote.
+
+Implicit Hyperlink Targets
+==========================
+
+Implicit hyperlink targets are generated by section titles, footnotes,
+and citations, and may also be generated by extension constructs.
+Implicit hyperlink targets otherwise behave identically to explicit
+`hyperlink targets`_.
+
+Problems of ambiguity due to conflicting duplicate implicit and
+explicit reference names are avoided by following this procedure:
+
+1. `Explicit hyperlink targets`_ override any implicit targets having
+   the same reference name.  The implicit hyperlink targets are
+   removed, and level-1 (info) system messages are inserted.
+
+2. Duplicate implicit hyperlink targets are removed, and level-1
+   (info) system messages inserted.  For example, if two or more
+   sections have the same title (such as "Introduction" subsections of
+   a rigidly-structured document), there will be duplicate implicit
+   hyperlink targets.
+
+3. Duplicate explicit hyperlink targets are removed, and level-2
+   (warning) system messages are inserted.  Exception: duplicate
+   `external hyperlink targets`_ (identical hyperlink names and
+   referenced URIs) do not conflict, and are not removed.
+
+System messages are inserted where target links have been removed.
+See "Error Handling" in `PEP 258`_.
+
+The parser must return a set of *unique* hyperlink targets.  The
+calling software (such as the Docutils_) can warn of unresolvable
+links, giving reasons for the messages.
+
+
+Inline Markup
+=============
+
+In reStructuredText, inline markup applies to words or phrases within
+a text block.  The same whitespace and punctuation that serves to
+delimit words in written text is used to delimit the inline markup
+syntax constructs (see the `inline markup recognition rules`_ for
+details).  The text within inline markup may not begin or end with
+whitespace.  Arbitrary `character-level inline markup`_ is supported
+although not encouraged.  Inline markup cannot be nested.
+
+There are nine inline markup constructs.  Five of the constructs use
+identical start-strings and end-strings to indicate the markup:
+
+- emphasis_: "*"
+- `strong emphasis`_: "**"
+- `interpreted text`_: "`"
+- `inline literals`_: "``"
+- `substitution references`_: "|"
+
+Three constructs use different start-strings and end-strings:
+
+- `inline internal targets`_: "_`" and "`"
+- `footnote references`_: "[" and "]_"
+- `hyperlink references`_: "`" and "\`_" (phrases), or just a
+  trailing "_" (single words)
+
+`Standalone hyperlinks`_ are recognized implicitly, and use no extra
+markup.
+
+Inline comments are not supported.
+
+
+Inline markup recognition rules
+-------------------------------
+
+Inline markup start-strings and end-strings are only recognized if
+the following conditions are met:
+
+1. Inline markup start-strings must be immediately followed by
+   non-whitespace.
+
+2. Inline markup end-strings must be immediately preceded by
+   non-whitespace.
+
+3. The inline markup end-string must be separated by at least one
+   character from the start-string.
+
+4. Both, inline markup start-string and end-string must not be preceded by
+   an unescaped backslash (except for the end-string of `inline literals`_).
+   See `Escaping Mechanism`_ above for details.
+
+5. If an inline markup start-string is immediately preceded by one of the
+   ASCII characters ``' " < ( [ {`` or a similar
+   non-ASCII character [#openers]_, it must not be followed by the
+   corresponding closing character from ``' " > ) ] }`` or a similar
+   non-ASCII character [#closers]_. (For quotes, matching characters can
+   be any of the `quotation marks in international usage`_.)
+
+If the configuration setting `character-level-inline-markup`_ is False
+(default), additional conditions apply to the characters "around" the
+inline markup:
+
+6. Inline markup start-strings must start a text block or be
+   immediately preceded by
+
+   * whitespace,
+   * one of the ASCII characters ``- : / ' " < ( [ {``
+   * or a similar non-ASCII punctuation character. [#pre-chars]_
+
+7. Inline markup end-strings must end a text block or be immediately
+   followed by
+
+   * whitespace,
+   * one of the ASCII characters ``- . , : ; ! ? \ / ' " ) ] } >``
+   * or a similar non-ASCII punctuation character. [#post-chars]_
+
+.. [#openers]    `Unicode categories`_ `Ps` (Open), `Pi` (Initial quote),
+                 or `Pf` (Final quote). [#uni-version]_
+.. [#closers]    Unicode categories `Pe` (Close), `Pi` (Initial quote),
+                 or `Pf` (Final quote). [#uni-version]_
+.. [#pre-chars]  Unicode categories `Ps` (Open), `Pi` (Initial quote),
+                 `Pf` (Final quote), `Pd` (Dash), or `Po` (Other). [#uni-version]_
+.. [#post-chars] Unicode categories  `Pe` (Close), `Pi` (Initial quote),
+                 `Pf` (Final quote), `Pd` (Dash), or `Po` (Other). [#uni-version]_
+
+.. [#uni-version] The category of some characters changed with the
+   development of the Unicode standard.
+   Docutils 0.13 uses `Unicode version 5.2.0`_.
+
+.. _Unicode categories:
+   https://www.unicode.org/Public/5.1.0/ucd/UCD.html#General_Category_Values
+.. _Unicode version 5.2.0: https://www.unicode.org/Public/5.2.0/
+.. _quotation marks in international usage:
+   https://en.wikipedia.org/wiki/Quotation_mark,_non-English_usage
+
+The inline markup recognition rules were devised to allow 90% of non-markup
+uses of "*", "`", "_", and "|" without escaping. For example, none of the
+following terms are recognized as containing inline markup strings:
+
+- 2 * x  a ** b  (* BOM32_* ` `` _ __ | (breaks rule 1)
+- || (breaks rule 3)
+- "*" '|' (*) [*] {*} <*>
+  â€˜*â€™ â€š*â€˜ â€˜*â€š â€™*â€™ â€š*â€™
+  â€œ*â€ â€ž*â€œ â€œ*â€ž â€*â€ â€ž*â€
+  Â»*Â« â€º*â€¹ Â«*Â» Â»*Â» â€º*â€º (breaks rule 5)
+- 2*x a**b O(N**2) e**(x*y) f(x)*f(y) a|b file*.*
+  __init__ __init__()  (breaks rule 6)
+
+No escaping is required inside the following inline markup examples:
+
+- ``*2 * x  *a **b *.txt*`` (breaks rule 2; renders as "*2 * x  *a **b *.txt*")
+- ``*2*x a**b O(N**2) e**(x*y) f(x)*f(y) a*(1+2)*``
+  (breaks rule 7; renders as "*2*x a**b O(N**2) e**(x*y) f(x)*f(y) a*(1+2)*")
+
+It may be desirable to use `inline literals`_ for some of these anyhow,
+especially if they represent code snippets.  It's a judgment call.
+
+The following terms *do* require either literal-quoting or escaping to avoid
+misinterpretation::
+
+    *4, class_, *args, **kwargs, `TeX-quoted', *ML, *.txt
+
+In most use cases, `inline literals`_ or `literal blocks`_ are the best
+choice (by default, this also selects a monospaced font). Alternatively, the
+inline markup characters can be escaped::
+
+    \*4, class\_, \*args, \**kwargs, \`TeX-quoted', \*ML, \*.txt
+
+
+For languages that don't use whitespace between words (e.g. Japanese or
+Chinese) it is recommended to set `character-level-inline-markup`_ to
+True and eventually escape inline markup characters.
+The examples breaking rules 6 and 7 above show which constructs may need
+special attention.
+
+.. _character-level-inline-markup:
+   ../../user/config.html#character-level-inline-markup
+
+
+Recognition order
+-----------------
+
+Inline markup delimiter characters are used for multiple constructs,
+so to avoid ambiguity there must be a specific recognition order for
+each character.  The inline markup recognition order is as follows:
+
+- Asterisks: `Strong emphasis`_ ("**") is recognized before emphasis_
+  ("*").
+
+- Backquotes: `Inline literals`_ ("``"), `inline internal targets`_
+  (leading "_`", trailing "`"), are mutually independent, and are
+  recognized before phrase `hyperlink references`_ (leading "`",
+  trailing "\`_") and `interpreted text`_ ("`").
+
+- Trailing underscores: Footnote references ("[" + label + "]_") and
+  simple `hyperlink references`_ (name + trailing "_") are mutually
+  independent.
+
+- Vertical bars: `Substitution references`_ ("|") are independently
+  recognized.
+
+- `Standalone hyperlinks`_ are the last to be recognized.
+
+
+Character-Level Inline Markup
+-----------------------------
+
+It is possible to mark up individual characters within a word with
+backslash escapes (see `Escaping Mechanism`_ above).  Backslash
+escapes can be used to allow arbitrary text to immediately follow
+inline markup::
+
+    Python ``list``\s use square bracket syntax.
+
+The backslash will disappear from the processed document.  The word
+"list" will appear as inline literal text, and the letter "s" will
+immediately follow it as normal text, with no space in-between.
+
+Arbitrary text may immediately precede inline markup using
+backslash-escaped whitespace::
+
+    Possible in *re*\ ``Structured``\ *Text*, though not encouraged.
+
+The backslashes and spaces separating "re", "Structured", and "Text"
+above will disappear from the processed document.
+
+.. CAUTION::
+
+   The use of backslash-escapes for character-level inline markup is
+   not encouraged.  Such use is ugly and detrimental to the
+   unprocessed document's readability.  Please use this feature
+   sparingly and only where absolutely necessary.
+
+
+Emphasis
+--------
+
+Doctree element: emphasis_.
+
+Start-string = end-string = "*".
+
+Text enclosed by single asterisk characters is emphasized::
+
+    This is *emphasized text*.
+
+Emphasized text is typically displayed in italics.
+
+
+Strong Emphasis
+---------------
+
+Doctree element: strong_.
+
+Start-string = end-string = "**".
+
+Text enclosed by double-asterisks is emphasized strongly::
+
+    This is **strong text**.
+
+Strongly emphasized text is typically displayed in boldface.
+
+
+Interpreted Text
+----------------
+
+Doctree element: depends on the explicit or implicit role and
+processing.
+
+Start-string = end-string = "`".
+
+Interpreted text is text that is meant to be related, indexed, linked,
+summarized, or otherwise processed, but the text itself is typically
+left alone.  Interpreted text is enclosed by single backquote
+characters::
+
+    This is `interpreted text`.
+
+The "role" of the interpreted text determines how the text is
+interpreted.  The role may be inferred implicitly (as above; the
+"default role" is used) or indicated explicitly, using a role marker.
+A role marker consists of a colon, the role name, and another colon.
+A role name is a single word consisting of alphanumerics plus isolated
+internal hyphens, underscores, plus signs, colons, and periods;
+no whitespace or other characters are allowed.  A role marker is
+either a prefix or a suffix to the interpreted text, whichever reads
+better; it's up to the author::
+
+    :role:`interpreted text`
+
+    `interpreted text`:role:
+
+Interpreted text allows extensions to the available inline descriptive
+markup constructs.  To emphasis_, `strong emphasis`_, `inline
+literals`_, and `hyperlink references`_, we can add "title reference",
+"index entry", "acronym", "class", "red", "blinking" or anything else
+we want (as long as it is a simple `reference name`_).
+Only pre-determined roles are recognized; unknown roles will
+generate errors.  A core set of standard roles is implemented in the
+reference parser; see `reStructuredText Interpreted Text Roles`_ for
+individual descriptions.  The role_ directive can be used to define
+custom interpreted text roles.  In addition, applications may support
+specialized roles.
+
+In `field lists`_, care must be taken when using interpreted text with
+explicit roles in field names: the role must be a suffix to the
+interpreted text. The following are recognized as field list items::
+
+    :`field name`:code:: interpreted text with explicit role as suffix
+
+    :a `complex`:code:\  field name: a backslash-escaped space
+                                     is necessary
+
+The following are **not** recognized as field list items::
+
+    ::code:`not a field name`: paragraph with interpreted text
+
+    :code:`not a field name`: paragraph with interpreted text
+
+Edge cases::
+
+    :field\:`name`: interpreted text (standard role) requires
+                    escaping the leading colon in a field name
+
+    :field:\`name`: not interpreted text
+
+
+Inline Literals
+---------------
+
+Doctree element: literal_.
+
+Start-string = end-string = "``".
+
+Text enclosed by double-backquotes is treated as inline literals::
+
+    This text is an example of ``inline literals``.
+
+Inline literals may contain any characters except two adjacent
+backquotes in an end-string context (according to the recognition
+rules above).  No markup interpretation (including backslash-escape
+interpretation) is done within inline literals.
+
+Line breaks and sequences of whitespace characters
+are *not* protected in inline literals.
+Although a reStructuredText parser will preserve them in its output,
+the final representation of the processed document depends on the
+output formatter, thus the preservation of whitespace cannot be
+guaranteed.  If the preservation of line breaks and/or other
+whitespace is important, `literal blocks`_ should be used.
+
+Inline literals are useful for short code snippets.  For example::
+
+    The regular expression ``[+-]?(\d+(\.\d*)?|\.\d+)`` matches
+    floating-point numbers (without exponents).
+
+
+Hyperlink References
+--------------------
+
+Doctree element: reference_.
+
+- Named hyperlink references:
+
+  - No start-string, end-string = "_".
+  - Start-string = "`", end-string = "\`_".  (Phrase references.)
+
+- Anonymous hyperlink references:
+
+  - No start-string, end-string = "__".
+  - Start-string = "`", end-string = "\`__".  (Phrase references.)
+
+Hyperlink references are indicated by a trailing underscore, "_",
+except for `standalone hyperlinks`_ which are recognized
+independently.  The underscore can be thought of as a right-pointing
+arrow.  The trailing underscores point away from hyperlink references,
+and the leading underscores point toward `hyperlink targets`_.
+
+Hyperlinks consist of two parts.  In the text body, there is a source
+link, a reference name with a trailing underscore (or two underscores
+for `anonymous hyperlinks`_)::
+
+    See the Python_ home page for info.
+
+A target link with a matching reference name must exist somewhere else
+in the document.  See `Hyperlink Targets`_ for a full description).
+
+`Anonymous hyperlinks`_ (which see) do not use reference names to
+match references to targets, but otherwise behave similarly to named
+hyperlinks.
+
+
+Embedded URIs and Aliases
+`````````````````````````
+
+A hyperlink reference may directly embed a target URI or (since
+DocutilsÂ 0.11) a hyperlink reference within angle brackets ("<...>")
+as follows::
+
+    See the `Python home page <https://www.python.org>`_ for info.
+
+    This `link <Python home page_>`_ is an alias to the link above.
+
+This is exactly equivalent to::
+
+    See the `Python home page`_ for info.
+
+    This link_ is an alias to the link above.
+
+    .. _Python home page: https://www.python.org
+    .. _link: `Python home page`_
+
+The bracketed URI must be preceded by whitespace and be the last text
+before the end string.
+
+With a single trailing underscore, the reference is named and the same
+target URI may be referred to again.
+With two trailing underscores, the reference and target are both
+anonymous, and the target cannot be referred to again.  These are
+"one-off" hyperlinks.  For example::
+
+    `RFC 2396 <https://www.rfc-editor.org/rfc/rfc2396.txt>`__ and `RFC
+    2732 <https://www.rfc-editor.org/rfc/rfc2732.txt>`__ together
+    define the syntax of URIs.
+
+Equivalent to::
+
+    `RFC 2396`__ and `RFC 2732`__ together define the syntax of URIs.
+
+    __ https://www.rfc-editor.org/rfc/rfc2396.txt
+    __ https://www.rfc-editor.org/rfc/rfc2732.txt
+
+`Standalone hyperlinks`_ are treated as URIs, even if they end with an
+underscore like in the example of a Python function documentation::
+
+    `__init__ <http:example.py.html#__init__>`__
+
+If a target URI that is not recognized as `standalone hyperlink`_ happens
+to end with an underscore, this needs to be backslash-escaped to avoid
+being parsed as hyperlink reference. For example ::
+
+    Use the `source <parrots.txt\_>`__.
+
+creates an anonymous reference to the file ``parrots.txt_``.
+
+If the reference text happens to end with angle-bracketed text that is
+*not* a URI or hyperlink reference, at least one angle-bracket needs to
+be backslash-escaped or an escaped space should follow. For example, here
+are three references to titles describing a tag::
+
+    See `HTML Element: \<a>`_, `HTML Element: <b\> `_, and
+    `HTML Element: <c>\ `_.
+
+The reference text may also be omitted, in which case the URI will be
+duplicated for use as the reference text.  This is useful for relative
+URIs where the address or file name is also the desired reference
+text::
+
+    See `<a_named_relative_link>`_ or `<an_anonymous_relative_link>`__
+    for details.
+
+.. CAUTION::
+
+   This construct offers easy authoring and maintenance of hyperlinks
+   at the expense of general readability.  Inline URIs, especially
+   long ones, inevitably interrupt the natural flow of text.  For
+   documents meant to be read in source form, the use of independent
+   block-level `hyperlink targets`_ is **strongly recommended**.  The
+   embedded URI construct is most suited to documents intended *only*
+   to be read in processed form.
+
+
+Inline Internal Targets
+------------------------
+
+Doctree element: target_.
+
+Start-string = "_`", end-string = "`".
+
+Inline internal targets are the equivalent of explicit `internal
+hyperlink targets`_, but may appear within running text.  The syntax
+begins with an underscore and a backquote, is followed by a hyperlink
+name or phrase, and ends with a backquote.  Inline internal targets
+may not be anonymous.
+
+For example, the following paragraph contains a hyperlink target named
+"Norwegian Blue"::
+
+    Oh yes, the _`Norwegian Blue`.  What's, um, what's wrong with it?
+
+See `Implicit Hyperlink Targets`_ for the resolution of duplicate
+reference names.
+
+
+Footnote References
+-------------------
+
+See also: Footnotes_
+
+Doctree element: footnote_reference_.
+
+Configuration settings:
+`footnote_references <footnote_references setting_>`_,
+trim_footnote_reference_space_.
+
+.. _trim_footnote_reference_space:
+   ../../user/config.html#trim-footnote-reference-space
+
+Start-string = "[", end-string = "]_".
+
+Each footnote reference consists of a square-bracketed label followed
+by a trailing underscore.  Footnote labels are one of:
+
+- one or more digits (i.e., a number),
+
+- a single "#" (denoting `auto-numbered footnotes`_),
+
+- a "#" followed by a simple `reference name`_ (an `autonumber label`_),
+  or
+
+- a single "*" (denoting `auto-symbol footnotes`_).
+
+For example::
+
+    Please RTFM [1]_.
+
+    .. [1] Read The Fine Manual
+
+`Inline markup recognition rules`_ may require whitespace in front of the
+footnote reference. To remove the whitespace from the output, use an
+escaped whitespace character (see `Escaping Mechanism`_) or set the
+trim_footnote_reference_space_ configuration setting. Leading whitespace
+is removed by default, if the `footnote_references setting`_ is
+"superscript".
+
+
+Citation References
+-------------------
+
+See also: Citations_
+
+Doctree element: citation_reference_.
+
+Start-string = "[", end-string = "]_".
+
+Each citation reference consists of a square-bracketed label followed
+by a trailing underscore.  Citation labels are simple `reference
+names`_ (case-insensitive single words, consisting of alphanumerics
+plus internal hyphens, underscores, and periods; no whitespace).
+
+For example::
+
+    Here is a citation reference: [CIT2002]_.
+
+
+Substitution References
+-----------------------
+
+Doctree elements: substitution_reference_, reference_.
+
+Start-string = "|", end-string = "|" (optionally followed by "_" or
+"__").
+
+Vertical bars are used to bracket the substitution reference text.  A
+substitution reference may also be a hyperlink reference by appending
+a "_" (named) or "__" (anonymous) suffix; the substitution text is
+used for the reference text in the named case.
+
+The processing system replaces substitution references with the
+processed contents of the corresponding `substitution definitions`_
+(which see for the definition of "correspond").  Substitution
+definitions produce inline-compatible elements.
+
+Examples::
+
+    This is a simple |substitution reference|.  It will be replaced by
+    the processing system.
+
+    This is a combination |substitution and hyperlink reference|_.  In
+    addition to being replaced, the replacement text or element will
+    refer to the "substitution and hyperlink reference" target.
+
+.. _standalone hyperlink:
+
+Standalone Hyperlinks
+---------------------
+
+Doctree element: reference_.
+
+No start-string or end-string.
+
+A URI (absolute URI [#URI]_ or standalone email address) within a text
+block is treated as a general external hyperlink with the URI itself
+as the link's text.  For example::
+
+    See https://www.python.org for info.
+
+would be marked up in HTML as::
+
+    See <a href="https://www.python.org">https://www.python.org</a> for
+    info.
+
+Two forms of URI are recognized:
+
+1. Absolute URIs.  These consist of a scheme, a colon (":"), and a
+   scheme-specific part whose interpretation depends on the scheme.
+
+   The scheme is the name of the protocol, such as "http", "ftp",
+   "mailto", or "telnet".  The scheme consists of an initial letter,
+   followed by letters, numbers, and/or "+", "-", ".".  Recognition is
+   limited to known schemes, per the `Official IANA Registry of URI
+   Schemes`_ and the W3C's `Retired Index of WWW Addressing Schemes`_.
+
+   The scheme-specific part of the resource identifier may be either
+   hierarchical or opaque:
+
+   - Hierarchical identifiers begin with one or two slashes and may
+     use slashes to separate hierarchical components of the path.
+     Examples are web pages and FTP sites::
+
+         https://www.python.org
+
+         ftp://ftp.python.org/pub/python
+
+   - Opaque identifiers do not begin with slashes.  Examples are
+     email addresses and newsgroups::
+
+         mailto:someone@somewhere.com
+
+         news:comp.lang.python
+
+   With queries, fragments, and %-escape sequences, URIs can become
+   quite complicated.  A reStructuredText parser must be able to
+   recognize any absolute URI, as defined in RFC2396_ and RFC2732_.
+
+2. Standalone email addresses, which are treated as if they were
+   absolute URIs with a "mailto:" scheme.  Example::
+
+       someone@somewhere.com
+
+Punctuation at the end of a URI is not considered part of the URI,
+unless the URI is terminated by a closing angle bracket (">").
+Backslashes may be used in URIs to escape markup characters,
+specifically asterisks ("*") and underscores ("_") which are valid URI
+characters (see `Escaping Mechanism`_ above).
+
+.. [#URI] Uniform Resource Identifier.  URIs are a general form of
+   URLs (Uniform Resource Locators).  For the syntax of URIs see
+   RFC2396_ and RFC2732_.
+
+
+Units
+=====
+
+(New in Docutils 0.3.10.)
+
+All measures consist of a positive floating point number in standard
+(non-scientific) notation and a unit, possibly separated by one or
+more spaces.
+
+Units are only supported where explicitly mentioned in the reference
+manuals.
+
+
+Length Units
+------------
+
+The following length units are supported by the reStructuredText
+parser:
+
+* em (em unit, the element's font size)
+* ex (ex unit, x-height of the elementâ€™s font)
+* mm (millimeters; 1Â mm = 1/1000Â m)
+* cm (centimeters; 1Â cm = 10Â mm)
+* in (inches; 1Â in = 2.54Â cm = 96Â px)
+* px (pixels, 1Â px = 1/96Â in) [#]_
+* pt (points; 1Â pt = 1/72Â in)
+* pc (picas; 1Â pc = 1/6Â in = 12Â pt)
+
+This set corresponds to the `length units in CSS2`_ (a subset of `length
+units in CSS3`_).
+
+.. [#] In LaTeX, the default definition is 1Â px = 1/72Â in (cf. `How to
+   configure the size of a pixel`_ in the LaTeX writer documentation).
+
+The following are all valid length values: "1.5em", "20 mm", ".5in".
+
+Length values without unit are completed with a writer-dependent
+default (e.g. "px" with HTML, "pt" with `latex2e`). See the writer
+specific documentation in the `user doc`__ for details.
+
+.. _length units in CSS2:
+   https://www.w3.org/TR/CSS2/syndata.html#length-units
+.. _length units in CSS3:
+   https://www.w3.org/TR/css-values-3/#absolute-lengths
+.. _How to configure the size of a pixel:
+   ../../user/latex.html#size-of-a-pixel
+__ ../../user/
+
+
+Percentage Units
+----------------
+
+Percentage values have a percent sign ("%") as unit.  Percentage
+values are relative to other values, depending on the context in which
+they occur.
+
+
+----------------
+ Error Handling
+----------------
+
+Doctree elements: system_message_, problematic_.
+
+Markup errors are handled according to the specification in `PEP
+258`_.
+
+
+.. _reStructuredText: https://docutils.sourceforge.io/rst.html
+.. _Docutils: https://docutils.sourceforge.io/
+.. _Docutils Generic DTD: ../docutils.dtd
+.. _transforms:
+   https://docutils.sourceforge.io/docutils/transforms/
+.. _Grouch: http://www.mems-exchange.org/software/grouch/
+.. _RFC822: https://www.rfc-editor.org/rfc/rfc822.txt
+.. _DocTitle transform:
+.. _DocInfo transform:
+   https://docutils.sourceforge.io/docutils/transforms/frontmatter.py
+.. _getopt.py:
+   https://docs.python.org/3/library/getopt.html
+.. _GNU libc getopt_long():
+   https://www.gnu.org/software/libc/manual/html_node/Getopt-Long-Options.html
+.. _doctest module:
+   https://docs.python.org/3/library/doctest.html
+.. _Emacs table mode: http://table.sourceforge.net/
+.. _Official IANA Registry of URI Schemes:
+   http://www.iana.org/assignments/uri-schemes
+.. _Retired Index of WWW Addressing Schemes:
+   https://www.w3.org/Addressing/schemes.html
+.. _World Wide Web Consortium: https://www.w3.org/
+.. _HTML Techniques for Web Content Accessibility Guidelines:
+   https://www.w3.org/TR/WCAG10-HTML-TECHS/#link-text
+.. _RFC2396: https://www.rfc-editor.org/rfc/rfc2396.txt
+.. _RFC2732: https://www.rfc-editor.org/rfc/rfc2732.txt
+.. _Zope: http://www.zope.com/
+.. _PEP 258: ../../peps/pep-0258.html
+.. _writers: ../../peps/pep-0258.html#writers
+
+.. _reStructuredText Directives: directives.html
+.. _admonition: directives.html#admonitions
+.. _code: directives.html#code
+.. _math: directives.html#math
+.. _raw: directives.html#raw
+.. _figure: directives.html#figure
+.. _image: directives.html#image
+.. _meta: directives.html#metadata
+.. _replace: directives.html#replace
+.. _role: directives.html#custom-interpreted-text-roles
+.. _table directive: directives.html#table
+.. _list table: directives.html#list-table
+.. _CSV table: directives.html#csv-table
+.. _custom roles: directives.html#role
+.. _reStructuredText Interpreted Text Roles: roles.html
+.. _"raw" role: roles.html#raw
+
+.. _Document Tree:
+.. _The Docutils Document Tree: ../doctree.html
+.. _"classes" attribute:  ../doctree.html#classes
+.. _topic: ../doctree.html#topic
+.. _address: ../doctree.html#address
+.. _author: ../doctree.html#author
+.. _authors: ../doctree.html#authors
+.. _contact: ../doctree.html#contact
+.. _copyright: ../doctree.html#copyright
+.. _date: ../doctree.html#date
+.. _topic: ../doctree.html#topic
+.. _organization: ../doctree.html#organization
+.. _revision: ../doctree.html#revision
+.. _status: ../doctree.html#status
+.. _version: ../doctree.html#version
+.. _docinfo: ../doctree.html#docinfo
+.. _field: ../doctree.html#field
+.. _section: ../doctree.html#section
+.. _bullet_list: ../doctree.html#bullet-list
+.. _list_item: ../doctree.html#list-item
+.. _enumerated_list: ../doctree.html#enumerated-list
+.. _list_item: ../doctree.html#list-item
+.. _definition_list: ../doctree.html#definition-list
+.. _definition_list_item: ../doctree.html#definition-list-item
+.. _term: ../doctree.html#term
+.. _classifier: ../doctree.html#classifier
+.. _definition: ../doctree.html#definition
+.. _field_list: ../doctree.html#field-list
+.. _field_name: ../doctree.html#field-name
+.. _field_body: ../doctree.html#field-body
+.. _option_list: ../doctree.html#option-list
+.. _option_list_item: ../doctree.html#option-list-item
+.. _option_group: ../doctree.html#option-group
+.. _option: ../doctree.html#option
+.. _option_string: ../doctree.html#option-string
+.. _option_argument: ../doctree.html#option-argument
+.. _description: ../doctree.html#description
+.. _line_block: ../doctree.html#line-block
+.. _line: ../doctree.html#line
+.. _table: ../doctree.html#table
+.. _tgroup: ../doctree.html#tgroup
+.. _colspec: ../doctree.html#colspec
+.. _thead: ../doctree.html#thead
+.. _tbody: ../doctree.html#tbody
+.. _title: ../doctree.html#title
+.. _row: ../doctree.html#row
+.. _entry: ../doctree.html#entry
+.. _identifier key: ../doctree.html#identifier-keys
+.. _document element: ../doctree.html#document
+.. _footnote: ../doctree.html#footnote
+.. _label: ../doctree.html#label
+.. _citation: ../doctree.html#citation
+.. _target: ../doctree.html#target
+.. _footnote_reference: ../doctree.html#footnote-reference
+.. _citation_reference: ../doctree.html#citation-reference
+.. _transition: ../doctree.html#transition
+.. _paragraph: ../doctree.html#paragraph
+.. _literal_block: ../doctree.html#literal-block
+.. _block_quote: ../doctree.html#block-quote
+.. _attribution: ../doctree.html#attribution
+.. _doctest_block: ../doctree.html#doctest-block
+.. _substitution_definition: ../doctree.html#substitution-definition
+.. _comment: ../doctree.html#comment
+.. _strong: ../doctree.html#strong
+.. _literal: ../doctree.html#literal
+.. _reference: ../doctree.html#reference
+.. _substitution_reference: ../doctree.html#substitution-reference
+.. _reference: ../doctree.html#reference
+.. _reference: ../doctree.html#reference
+.. _system_message: ../doctree.html#system-message
+.. _problematic: ../doctree.html#problematic
+
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   End:

--- a/tests/test_vectors/specification_expected.html
+++ b/tests/test_vectors/specification_expected.html
@@ -1,0 +1,2135 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+.r1 {font-weight: bold}
+.r2 {color: #ffffff; text-decoration-color: #ffffff; font-weight: bold}
+.r3 {color: #bd93f9; text-decoration-color: #bd93f9; background-color: #282a36; text-decoration: underline}
+.r4 {color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #282a36}
+.r5 {color: #f1fa8c; text-decoration-color: #f1fa8c; font-weight: bold}
+.r6 {color: #949494; text-decoration-color: #949494}
+.r7 {color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822}
+.r8 {color: #ff4689; text-decoration-color: #ff4689; background-color: #272822}
+.r9 {background-color: #272822}
+.r10 {color: #ae81ff; text-decoration-color: #ae81ff; background-color: #272822}
+.r11 {color: #e6db74; text-decoration-color: #e6db74; background-color: #272822}
+.r12 {color: #66d9ef; text-decoration-color: #66d9ef; background-color: #272822}
+.r13 {color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #282a36; font-style: italic}
+.r14 {color: #c6c6c6; text-decoration-color: #c6c6c6; background-color: #121212}
+.r15 {color: #ed007e; text-decoration-color: #ed007e; background-color: #1e0010}
+.r16 {color: #c6c6c6; text-decoration-color: #c6c6c6; background-color: #121212; text-decoration: underline}
+.r17 {color: #ff79c6; text-decoration-color: #ff79c6}
+.r18 {color: #ffffff; text-decoration-color: #ffffff}
+.r19 {color: #e4e4e4; text-decoration-color: #e4e4e4}
+.r20 {color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #282a36; font-weight: bold}
+.r21 {color: #a6e22e; text-decoration-color: #a6e22e; background-color: #272822}
+.r22 {color: #959077; text-decoration-color: #959077; background-color: #272822}
+.r23 {color: #50fa7b; text-decoration-color: #50fa7b; font-weight: bold}
+.r24 {color: #8be9fd; text-decoration-color: #8be9fd}
+.r25 {font-style: italic}
+.r26 {color: #ff5555; text-decoration-color: #ff5555}
+.r27 {color: #8be9fd; text-decoration-color: #8be9fd; font-weight: bold}
+.r28 {color: #ff79c6; text-decoration-color: #ff79c6; font-weight: bold}
+.r29 {color: #50fa7b; text-decoration-color: #50fa7b}
+.r30 {color: #bcbcbc; text-decoration-color: #bcbcbc}
+body {
+    color: #f8f8f2;
+    background-color: #282a36;
+}
+</style>
+</head>
+<body>
+    <pre style="font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace"><code style="font-family:inherit"><span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                        reStructuredText Markup Specification                                         ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃<span class="r1"> Field Name </span>┃<span class="r1"> Field Value                                            </span>┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ <span class="r1">Author    </span> │ David Goodger                                          │
+├────────────┼────────────────────────────────────────────────────────┤
+│ <span class="r1">Contact   </span> │ docutils-develop@lists.sourceforge.net                 │
+├────────────┼────────────────────────────────────────────────────────┤
+│ <span class="r1">Revision  </span> │ $Revision: 8959 $                                      │
+├────────────┼────────────────────────────────────────────────────────┤
+│ <span class="r1">Date      </span> │ $Date: 2022-01-21 14:45:42 +0100 (Fr, 21. JÃ¤n 2022) $ │
+├────────────┼────────────────────────────────────────────────────────┤
+│ <span class="r1">Copyright </span> │ This document has been placed in the public domain.    │
+└────────────┴────────────────────────────────────────────────────────┘
+<span class="r2">╭─────────────────────────────────────────────────────── Note:  ───────────────────────────────────────────────────────╮</span>
+<span class="r2">│ This document is a detailed technical specification; it is not a tutorial or a primer.  If this is your first        │</span>
+<span class="r2">│ exposure to reStructuredText, please read A ReStructuredText Primer and the Quick reStructuredText user reference    │</span>
+<span class="r2">│ first.                                                                                                               │</span>
+<span class="r2">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<a class="r3" href="https://docutils.sourceforge.io/rst.html">reStructuredText</a><span class="r4"> is plaintext that uses simple and intuitive constructs to indicate the structure of a document.  These </span>
+<span class="r4">constructs are equally easy to read in raw and processed forms.  This document is itself an example of reStructuredText </span>
+<span class="r4">(raw, if you are reading the text file, or processed, if you are reading an HTML document, for example).  The </span>
+<span class="r4">reStructuredText parser is a component of </span><span class="r3">Docutils</span><span class="r4">.</span>
+
+<span class="r4">Simple, implicit markup is used to indicate special constructs, such as section headings, bullet lists, and emphasis.  </span>
+<span class="r4">The markup used is as minimal and unobtrusive as possible.  Less often-used constructs and extensions to the basic </span>
+<span class="r4">reStructuredText syntax may have more elaborate or explicit markup.</span>
+
+<span class="r4">reStructuredText is applicable to documents of any length, from the very small (such as inline program documentation </span>
+<span class="r4">fragments, e.g. Python docstrings) to the quite large (this document).</span>
+
+<span class="r4">The first section gives a quick overview of the syntax of the reStructuredText markup by example.  A complete </span>
+<span class="r4">specification is given in the </span><span class="r3">Syntax Details</span><span class="r4"> section.</span>
+
+<span class="r3">Literal blocks</span><span class="r4"> (in which no markup processing is done) are used for examples throughout this document, to illustrate the</span>
+<span class="r4">plaintext markup.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                       Contents                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                Quick Syntax Overview                                                 ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">A reStructuredText document is made up of body or block-level elements, and may be structured into sections.  </span><span class="r3">Sections</span><span class="r4"> </span>
+<span class="r4">are indicated through title style (underlines &amp; optional overlines). Sections contain body elements and/or subsections. </span>
+<span class="r4">Some body elements contain further elements, such as lists containing list items, which in turn may contain paragraphs </span>
+<span class="r4">and other body elements.  Others, such as paragraphs, contain text and </span><span class="r3">inline markup</span><span class="r4"> elements.</span>
+
+<span class="r4">Here are examples of </span><span class="r3">body elements</span><span class="r4">:</span>
+
+<span class="r5"> • </span>Paragraphs (and inline markup):  Paragraphs contain text and may contain inline markup: *emphasis*, **strong emphasis
+`interpreted text`, ``inline literals``, standalone hyperlinks (https://www.python.org), external hyperlinks (Python_), 
+internal cross-references (example_), footnote references ([1]_), citation references ([CIT2002]_), substitution 
+references (|example|), and _`inline internal targets`.  Paragraphs are separated by blank lines and are left-aligned.
+<span class="r5"> • </span>Five types of lists:  Bullet lists:  - This is a bullet list.  - Bullets can be &quot;*&quot;, &quot;+&quot;, or &quot;-&quot;.  Enumerated lists: 
+This is an enumerated list.  2. Enumerators may be arabic numbers, letters, or roman    numerals.  Definition lists:  
+what     Definition lists associate a term with a definition.  how     The term is a one-line phrase, and the definition
+is one     or more paragraphs or body elements, indented relative to     the term.  Field lists:  :what: Field lists map
+field names to field bodies, like        database records.  They are often part of an extension        syntax.  :how: 
+The field marker is a colon, the field name, and a       colon.        The field body may contain one or more body 
+elements,       indented relative to the field marker.  Option lists, for listing command-line options:  -a            
+command-line option &quot;a&quot; -b file       options can have arguments               and long descriptions --long        
+options can be long also --input=file  long options can also have               arguments /V            DOS/VMS-style 
+options too  There must be at least two spaces between the option and the description.
+<span class="r5"> • </span>Literal blocks:  Literal blocks are either indented or line-prefix-quoted blocks, and indicated with a double-colon 
+(&quot;::&quot;) at the end of the preceding paragraph (right here --&gt;)::      if literal_block:         text = &#x27;is left as-is&#x27;   
+spaces_and_linebreaks = &#x27;are preserved&#x27;         markup_processing = None
+<span class="r5"> • </span>Block quotes:  Block quotes consist of indented body elements:      This theory, that is mine, is mine.      -- Anne 
+(Miss)
+<span class="r5"> • </span>Doctest blocks:  &gt;&gt;&gt; print &#x27;Python-specific usage examples; begun with &quot;&gt;&gt;&gt;&quot;&#x27; Python-specific usage examples; begun w
+&quot;&gt;&gt;&gt;&quot; &gt;&gt;&gt; print &#x27;(cut and pasted from interactive Python sessions)&#x27; (cut and pasted from interactive Python sessions)
+<span class="r5"> • </span>Two syntaxes for tables:  Grid tables; complete, but complex and verbose:  
++------------------------+------------+----------+ | Header row, column 1   | Header 2   | Header 3 | 
++========================+============+==========+ | body row 1, column 1   | column 2   | column 3 | 
++------------------------+------------+----------+ | body row 2             | Cells may span        | 
++------------------------+-----------------------+  Simple tables; easy and compact, but limited:  ==================== 
+==========  ========== Header row, column 1  Header 2    Header 3 ====================  ==========  ========== body row 
+1, column 1  column 2    column 3 body row 2            Cells may span columns ====================  
+======================
+  <span class="r5"> ∘ </span>Explicit markup blocks all begin with an explicit block marker, two periods and a space:
+  <span class="r5"> ∘ </span>Footnotes:  .. [1] A footnote contains body elements, consistently    indented by at least 3 spaces.  Citations:  .
+[CIT2002] Just like a footnote, except the label is    textual.  Hyperlink targets:  .. _Python: https://www.python.org 
+.. _example:  The &quot;_example&quot; target above points to this paragraph.  Directives:  .. image:: mylogo.png  Substitution 
+definitions:  .. |symbol here| image:: symbol.png  Comments:  .. Comments begin with two dots and a space.  Anything may
+follow, except for the syntax of footnotes/citations,    hyperlink targets, directives, or substitution definitions.
+    <span class="r5"> ▪ </span>Footnotes:  .. [1] A footnote contains body elements, consistently    indented by at least 3 spaces.
+    <span class="r5"> ▪ </span>Citations:  .. [CIT2002] Just like a footnote, except the label is    textual.
+    <span class="r5"> ▪ </span>Hyperlink targets:  .. _Python: https://www.python.org  .. _example:  The &quot;_example&quot; target above points to this 
+paragraph.
+    <span class="r5"> ▪ </span>Directives:  .. image:: mylogo.png
+    <span class="r5"> ▪ </span>Substitution definitions:  .. |symbol here| image:: symbol.png
+    <span class="r5"> ▪ </span>Comments:  .. Comments begin with two dots and a space.  Anything may    follow, except for the syntax of 
+footnotes/citations,    hyperlink targets, directives, or substitution definitions.
+<span class="r5"> • </span>Comments:  .. Comments begin with two dots and a space.  Anything may    follow, except for the syntax of 
+footnotes/citations,    hyperlink targets, directives, or substitution definitions.
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                    Syntax Details                                                    ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Descriptions below list &quot;doctree elements&quot; (document tree element names; XML DTD generic identifiers) corresponding to </span>
+<span class="r4">syntax constructs.  For details on the hierarchy of elements, please see </span><a class="r3" href="../doctree.html">The Docutils Document Tree</a><span class="r4"> and the </span><a class="r3" href="../docutils.dtd">Docutils </a>
+<a class="r3" href="../docutils.dtd">Generic DTD</a><span class="r4"> XML document type definition.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      Whitespace                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Spaces are recommended for </span><span class="r3">indentation</span><span class="r4">, but tabs may also be used. Tabs will be converted to spaces.  Tab stops are at </span>
+<span class="r4">every 8th column (processing systems may make this value configurable).</span>
+
+<span class="r4">Other whitespace characters (form feeds [chr(12)] and vertical tabs [chr(11)]) are converted to single spaces before </span>
+<span class="r4">processing.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     Blank Lines                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Blank lines are used to separate paragraphs and other elements. Multiple successive blank lines are equivalent to a </span>
+<span class="r4">single blank line, except within literal blocks (where all whitespace is preserved). Blank lines may be omitted when the</span>
+<span class="r4">markup makes element separation unambiguous, in conjunction with indentation.  The first line of a document is treated </span>
+<span class="r4">as if it is preceded by a blank line, and the last line of a document is treated as if it is followed by a blank line.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     Indentation                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Indentation is used to indicate -- and is only significant in indicating -- block quotes, definitions (in </span><span class="r3">definition </span>
+<span class="r3">lists</span><span class="r4">), and local nested content:</span>
+
+<span class="r5"> • </span>list item content (multi-line contents of list items, and multiple body elements within a list item, including nested
+lists),
+<span class="r5"> • </span>the content of literal blocks, and
+<span class="r5"> • </span>the content of explicit markup blocks (directives, footnotes, ...).
+<span class="r4">Any text whose indentation is less than that of the current level (i.e., unindented text or &quot;dedents&quot;) ends the current </span>
+<span class="r4">level of indentation.Since all indentation is significant, the level of indentation must be consistent.  For example, </span>
+<span class="r4">indentation is the sole markup indicator for </span><span class="r3">block quotes</span><span class="r4">:</span>
+
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">This </span><span class="r8">is</span><span class="r7"> a top</span><span class="r8">-</span><span class="r7">level paragraph</span><span class="r8">.</span><span class="r9">                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    This paragraph belongs to a first</span><span class="r8">-</span><span class="r7">level block quote</span><span class="r8">.</span><span class="r9">                                                            </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    Paragraph </span><span class="r10">2</span><span class="r7"> of the first</span><span class="r8">-</span><span class="r7">level block quote</span><span class="r8">.</span><span class="r9">                                                                     </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Multiple levels of indentation within a block quote will result in more complex structures:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">This </span><span class="r8">is</span><span class="r7"> a top</span><span class="r8">-</span><span class="r7">level paragraph</span><span class="r8">.</span><span class="r9">                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    This paragraph belongs to a first</span><span class="r8">-</span><span class="r7">level block quote</span><span class="r8">.</span><span class="r9">                                                            </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        This paragraph belongs to a second</span><span class="r8">-</span><span class="r7">level block quote</span><span class="r8">.</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">Another top</span><span class="r8">-</span><span class="r7">level paragraph</span><span class="r8">.</span><span class="r9">                                                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        This paragraph belongs to a second</span><span class="r8">-</span><span class="r7">level block quote</span><span class="r8">.</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    This paragraph belongs to a first</span><span class="r8">-</span><span class="r7">level block quote</span><span class="r8">.</span><span class="r7">  The</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    second</span><span class="r8">-</span><span class="r7">level block quote above </span><span class="r8">is</span><span class="r7"> inside this first</span><span class="r8">-</span><span class="r7">level</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    block quote</span><span class="r8">.</span><span class="r9">                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">When a paragraph or other construct consists of more than one line of text, the lines must be left-aligned:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">This </span><span class="r8">is</span><span class="r7"> a paragraph</span><span class="r8">.</span><span class="r7">  The lines of</span><span class="r9">                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">this paragraph are aligned at the left</span><span class="r8">.</span><span class="r9">                                                                             </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    This paragraph has problems</span><span class="r8">.</span><span class="r7">  The</span><span class="r9">                                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">lines are </span><span class="r8">not</span><span class="r7"> left</span><span class="r8">-</span><span class="r7">aligned</span><span class="r8">.</span><span class="r7">  In addition</span><span class="r9">                                                                            </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  to potential misinterpretation, warning</span><span class="r9">                                                                           </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r8">and/or</span><span class="r7"> error messages will be generated</span><span class="r9">                                                                         </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  by the parser</span><span class="r8">.</span><span class="r9">                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Several constructs begin with a marker, and the body of the construct must be indented relative to the marker.  For </span>
+<span class="r4">constructs using simple markers (</span><span class="r3">bullet lists</span><span class="r4">, </span><span class="r3">enumerated lists</span><span class="r4">), the level of indentation of the body is determined by </span>
+<span class="r4">the position of the first line of text. For example:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">-</span><span class="r7"> This </span><span class="r8">is</span><span class="r7"> the first line of a bullet list</span><span class="r9">                                                                           </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  item</span><span class="r11">&#x27;s paragraph.  All lines must align</span><span class="r9">                                                                           </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  relative to the first line</span><span class="r8">.</span><span class="r9">                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">      This indented paragraph </span><span class="r8">is</span><span class="r7"> interpreted</span><span class="r9">                                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">      </span><span class="r12">as</span><span class="r7"> a block quote</span><span class="r8">.</span><span class="r9">                                                                                             </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  Another paragraph belonging to the first list item</span><span class="r8">.</span><span class="r9">                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7"> Because it </span><span class="r8">is</span><span class="r7"> </span><span class="r8">not</span><span class="r7"> sufficiently indented,</span><span class="r9">                                                                           </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7"> this paragraph does </span><span class="r8">not</span><span class="r7"> belong to the list</span><span class="r9">                                                                         </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7"> item (it</span><span class="r11">&#x27;s a block quote following the list).</span><span class="r9">                                                                      </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">The body of </span><span class="r3">explicit markup blocks</span><span class="r4">, </span><span class="r3">field lists</span><span class="r4">, and </span><span class="r3">option lists</span><span class="r4"> ends above the first line with the same or less </span>
+<span class="r4">indentation than the marker.  For example, field lists may have very long markers (containing the field names):</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">:Hello: This field has a short field name, so aligning the field</span><span class="r9">                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        body </span><span class="r12">with</span><span class="r7"> the first line </span><span class="r8">is</span><span class="r7"> feasible</span><span class="r8">.</span><span class="r9">                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">:Number</span><span class="r8">-</span><span class="r7">of</span><span class="r8">-</span><span class="r7">African</span><span class="r8">-</span><span class="r7">swallows</span><span class="r8">-</span><span class="r7">required</span><span class="r8">-</span><span class="r7">to</span><span class="r8">-</span><span class="r7">carry</span><span class="r8">-</span><span class="r7">a</span><span class="r8">-</span><span class="r7">coconut: It would</span><span class="r9">                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    be very difficult to align the field body </span><span class="r12">with</span><span class="r7"> the left edge</span><span class="r9">                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    of the first line</span><span class="r8">.</span><span class="r7">  It may even be preferable </span><span class="r8">not</span><span class="r7"> to begin the</span><span class="r9">                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    body on the same line </span><span class="r12">as</span><span class="r7"> the marker</span><span class="r8">.</span><span class="r9">                                                                            </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                  Escaping Mechanism                                                  ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">The character set universally available to plaintext documents, 7-bit ASCII, is limited.  No matter what characters are </span>
+<span class="r4">used for markup, they will already have multiple meanings in written text.  Therefore markup characters will sometimes </span>
+<span class="r4">appear in text without being intended as markup.  Any serious markup system requires an escaping mechanism to override </span>
+<span class="r4">the default meaning of the characters used for the markup.  In reStructuredText we use the </span><span class="r13">backslash</span><span class="r4">, commonly used as </span>
+<span class="r4">an escaping character in other domains.</span>
+
+<span class="r4">A backslash (</span><span class="r14">\</span><span class="r4">) escapes the following character.</span>
+
+<span class="r5"> • </span>&quot;Escaping&quot; backslash characters are represented by NULL characters in the Document Tree and removed from the output 
+document by the Docutils writers.
+<span class="r5"> • </span>Escaped non-white characters are prevented from playing a role in any markup interpretation. The escaped character 
+represents the character itself. (A literal backslash can be specified by two backslashes in a row -- the first 
+backslash escapes the second. )
+<span class="r5"> • </span>Escaped whitespace characters are removed from the output document together with the escaping backslash. This allows 
+character-level inline markup.  In URI context , backslash-escaped whitespace represents a single space.
+<span class="r4">Backslashes have no special meaning in literal context . Here, a single backslash represents a literal backslash, </span>
+<span class="r4">without having to double up. </span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                   Reference Names                                                    ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Reference names identify elements for cross-referencing.</span>
+
+<span class="r2">╭─────────────────────────────────────────────────────── Note:  ───────────────────────────────────────────────────────╮</span>
+<span class="r2">│ References to a target position in external, generated documents must use the auto-generated identifier key which    │</span>
+<span class="r2">│ may differ from the reference name due to restrictions on identifiers/labels in the output format.                   │</span>
+<span class="r2">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r4">Simple reference names are single words consisting of alphanumerics plus isolated (no two adjacent) internal hyphens, </span>
+<span class="r4">underscores, periods, colons and plus signs; no whitespace or other characters are allowed.  Footnote labels (</span><span class="r3">Footnotes</span><span class="r4"> </span>
+<span class="r4">&amp; </span><span class="r3">Footnote References</span><span class="r4">), citation labels (</span><span class="r3">Citations</span><span class="r4"> &amp; </span><span class="r3">Citation References</span><span class="r4">), </span><span class="r3">interpreted text</span><span class="r4"> roles, and some </span><span class="r3">hyperlink </span>
+<span class="r3">references</span><span class="r4"> use the simple reference name syntax.</span>
+
+<span class="r4">Reference names using punctuation or whose names are phrases (two or more space-separated words) are called </span>
+<span class="r4">&quot;phrase-references&quot;. Phrase-references are expressed by enclosing the phrase in backquotes and treating the backquoted </span>
+<span class="r4">text as a reference name:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">Want to learn about </span><span class="r15">`</span><span class="r7">my favorite programming language</span><span class="r15">`</span><span class="r7">_</span><span class="r15">?</span><span class="r9">                                                            </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> _my favorite programming language: https:</span><span class="r8">//</span><span class="r7">www</span><span class="r8">.</span><span class="r7">python</span><span class="r8">.</span><span class="r7">org</span><span class="r9">                                                        </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Simple reference names may also optionally use backquotes.</span>
+
+<span class="r4">Reference names are whitespace-neutral and case-insensitive.  When resolving reference names internally:</span>
+
+<span class="r5"> • </span>whitespace is normalized (one or more spaces, horizontal or vertical tabs, newlines, carriage returns, or form feeds,
+are interpreted as a single space), and
+<span class="r5"> • </span>case is normalized (all alphabetic characters are converted to lowercase).
+<span class="r4">For example, the following </span><span class="r3">hyperlink references</span><span class="r4"> are equivalent:</span>
+
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">-</span><span class="r7"> </span><span class="r15">`</span><span class="r7">A HYPERLINK</span><span class="r15">`</span><span class="r7">_</span><span class="r9">                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">-</span><span class="r7"> </span><span class="r15">`</span><span class="r7">a    hyperlink</span><span class="r15">`</span><span class="r7">_</span><span class="r9">                                                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">-</span><span class="r7"> </span><span class="r15">`</span><span class="r7">A</span><span class="r9">                                                                                                                </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  Hyperlink</span><span class="r15">`</span><span class="r7">_</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r3">Hyperlinks</span><span class="r4">, </span><span class="r3">footnotes</span><span class="r4">, and </span><span class="r3">citations</span><span class="r4"> all share the same namespace for reference names.  The labels of citations (simple </span>
+<span class="r4">reference names) and manually-numbered footnotes (numbers) are entered into the same database as other hyperlink names. </span>
+<span class="r4">This means that a </span><span class="r3">footnote</span><span class="r4"> (defined as &quot;</span><span class="r16">.. [#note]</span><span class="r4">&quot;) which can be referred to by a footnote reference (</span><span class="r16">[#note]_</span><span class="r4">), can </span>
+<span class="r4">also be referred to by a plain hyperlink reference (</span><span class="r16">note_</span><span class="r4">).  Of course, each type of reference (hyperlink, footnote, </span>
+<span class="r4">citation) may be processed and rendered differently.  Some care should be taken to avoid reference name conflicts.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                  Document Structure                                                  ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                       Document                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree element: </span><a class="r3" href="../doctree.html#document">document</a><span class="r4">.</span>
+
+<span class="r4">The top-level element of a parsed reStructuredText document is the &quot;document&quot; element.  After initial parsing, the </span>
+<span class="r4">document element is a simple container for a document fragment, consisting of </span><span class="r3">body elements</span><span class="r4">, </span><span class="r3">transitions</span><span class="r4">, and </span><span class="r3">sections</span><span class="r4">, </span>
+<span class="r4">but lacking a document title or other bibliographic elements.  The code that calls the parser may choose to run one or </span>
+<span class="r4">more optional post-parse </span><a class="r3" href="https://docutils.sourceforge.io/docutils/transforms/">transforms</a><span class="r4">, rearranging the document fragment into a complete document with a title and </span>
+<span class="r4">possibly other metadata elements (author, date, etc.; see </span><span class="r3">Bibliographic Fields</span><span class="r4">).</span>
+
+<span class="r4">Specifically, there is no way to indicate a document title and subtitle explicitly in reStructuredText.  Instead, a lone</span>
+<span class="r4">top-level section title (see </span><span class="r3">Sections</span><span class="r4"> below) can be treated as the document title.  Similarly, a lone second-level </span>
+<span class="r4">section title immediately after the &quot;document title&quot; can become the document subtitle.  The rest of the sections are </span>
+<span class="r4">then lifted up a level or two.  See the </span><span class="r3">DocTitle transform</span><span class="r4"> for details.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                       Sections                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree elements: </span><a class="r3" href="../doctree.html#section">section</a><span class="r4">, </span><a class="r3" href="../doctree.html#title">title</a><span class="r4">.</span>
+
+<span class="r4">Sections are identified through their titles, which are marked up with adornment: &quot;underlines&quot; below the title text, or </span>
+<span class="r4">underlines and matching &quot;overlines&quot; above the title.  An underline/overline is a single repeated punctuation character </span>
+<span class="r4">that begins in column 1 and forms a line extending at least as far as the right edge of the title text.   Specifically, </span>
+<span class="r4">an underline/overline character may be any non-alphanumeric printable 7-bit ASCII character .  When an overline is used,</span>
+<span class="r4">the length and character used must match the underline.  Underline-only adornment styles are distinct from </span>
+<span class="r4">overline-and-underline styles that use the same character.  There may be any number of levels of section titles, </span>
+<span class="r4">although some output formats may have limits (HTML has 6 levels).</span>
+
+<span class="r4">Rather than imposing a fixed number and order of section title adornment styles, the order enforced will be the order as</span>
+<span class="r4">encountered. The first style encountered will be an outermost title (like HTML H1), the second style will be a subtitle,</span>
+<span class="r4">the third will be a subsubtitle, and so on.</span>
+
+<span class="r4">Below are examples of section title styles:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">===============</span><span class="r9">                                                                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7"> Section Title</span><span class="r9">                                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">===============</span><span class="r9">                                                                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">---------------</span><span class="r9">                                                                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7"> Section Title</span><span class="r9">                                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">---------------</span><span class="r9">                                                                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">Section Title</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">=============</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">Section Title</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">-------------</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">Section Title</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r15">`````````````</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">Section Title</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r11">&#x27;&#x27;&#x27;&#x27;&#x27;&#x27;&#x27;&#x27;&#x27;&#x27;&#x27;&#x27;&#x27;</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">Section Title</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">.............</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">Section Title</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">~~~~~~~~~~~~~</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">Section Title</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">*************</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">Section Title</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+++++++++++++</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">Section Title</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">^^^^^^^^^^^^^</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">When a title has both an underline and an overline, the title text may be inset, as in the first two examples above.  </span>
+<span class="r4">This is merely aesthetic and not significant.  Underline-only title text may </span><span class="r13">not</span><span class="r4"> be inset.</span>
+
+<span class="r4">A blank line after a title is optional.  All text blocks up to the next title of the same or higher level are included </span>
+<span class="r4">in a section (or subsection, etc.).</span>
+
+<span class="r4">All section title styles need not be used, nor need any specific section title style be used.  However, a document must </span>
+<span class="r4">be consistent in its use of section titles: once a hierarchy of title styles is established, sections must use that </span>
+<span class="r4">hierarchy.</span>
+
+<span class="r4">Each section title automatically generates a hyperlink target pointing to the section.  The text of the hyperlink target</span>
+<span class="r4">(the &quot;reference name&quot;) is the same as that of the section title.  See </span><span class="r3">Implicit Hyperlink Targets</span><span class="r4"> for a complete </span>
+<span class="r4">description.</span>
+
+<span class="r4">Sections may contain </span><span class="r3">body elements</span><span class="r4">, </span><span class="r3">transitions</span><span class="r4">, and nested sections.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     Transitions                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree element: </span><a class="r3" href="../doctree.html#transition">transition</a><span class="r4">.</span>
+
+<span class="r17">▌ </span><span class="r18">Instead of subheads, extra space or a type ornament between</span>
+<span class="r18">paragraphs may be used to mark text divisions or to signal</span>
+<span class="r18">changes in subject or emphasis.</span>
+<span class="r19">  - (The Chicago Manual of Style, 14th edition, section 1.80)</span><span class="r4">Transitions are commonly seen in novels and short fiction, </span>
+<span class="r4">as a gap spanning one or more lines, with or without a type ornament such as a row of asterisks.  Transitions separate </span>
+<span class="r4">other body elements.  A transition should not begin or end a section or document, nor should two transitions be </span>
+<span class="r4">immediately adjacent.The syntax for a transition marker is a horizontal line of 4 or more repeated punctuation </span>
+<span class="r4">characters.  The syntax is the same as section title underlines without title text.  Transition markers require blank </span>
+<span class="r4">lines before and after:</span>
+
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">Para</span><span class="r8">.</span><span class="r9">                                                                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">----------</span><span class="r9">                                                                                                          </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">Para</span><span class="r8">.</span><span class="r9">                                                                                                               </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Unlike section title underlines, no hierarchy of transition markers is enforced, nor do differences in transition </span>
+<span class="r4">markers accomplish anything.  It is recommended that a single consistent style be used.</span>
+
+<span class="r4">The processing system is free to render transitions in output in any way it likes.  For example, horizontal rules (</span><span class="r14">&lt;hr&gt;</span><span class="r4">)</span>
+<span class="r4">in HTML output would be an obvious choice.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                    Body Elements                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      Paragraphs                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree element: </span><a class="r3" href="../doctree.html#paragraph">paragraph</a><span class="r4">.</span>
+
+<span class="r4">Paragraphs consist of blocks of left-aligned text with no markup indicating any other body element.  Blank lines </span>
+<span class="r4">separate paragraphs from each other and from other body elements.  Paragraphs may contain </span><span class="r3">inline markup</span><span class="r4">.</span>
+
+<span class="r4">Syntax diagram:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+------------------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> paragraph                    </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7">                              </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+------------------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+------------------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> paragraph                    </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7">                              </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+------------------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     Bullet Lists                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree elements: </span><a class="r3" href="../doctree.html#bullet-list">bullet_list</a><span class="r4">, </span><span class="r3">list_item</span><span class="r4">.</span>
+
+<span class="r4">A text block which begins with a &quot;*&quot;, &quot;+&quot;, &quot;-&quot;, &quot;â€¢&quot;, &quot;â€£&quot;, or &quot;âƒ&quot;, followed by whitespace, is a bullet list item </span>
+<span class="r4">(a.k.a. &quot;unordered&quot; list item).  List item bodies must be left-aligned and indented relative to the bullet; the text </span>
+<span class="r4">immediately after the bullet determines the indentation.  For example:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">-</span><span class="r7"> This </span><span class="r8">is</span><span class="r7"> the first bullet list item</span><span class="r8">.</span><span class="r7">  The blank line above the</span><span class="r9">                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  first list item </span><span class="r8">is</span><span class="r7"> required; blank lines between list items</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  (such </span><span class="r12">as</span><span class="r7"> below this paragraph) are optional</span><span class="r8">.</span><span class="r9">                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">-</span><span class="r7"> This </span><span class="r8">is</span><span class="r7"> the first paragraph </span><span class="r8">in</span><span class="r7"> the second item </span><span class="r8">in</span><span class="r7"> the list</span><span class="r8">.</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  This </span><span class="r8">is</span><span class="r7"> the second paragraph </span><span class="r8">in</span><span class="r7"> the second item </span><span class="r8">in</span><span class="r7"> the list</span><span class="r8">.</span><span class="r9">                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  The blank line above this paragraph </span><span class="r8">is</span><span class="r7"> required</span><span class="r8">.</span><span class="r7">  The left edge</span><span class="r9">                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  of this paragraph lines up </span><span class="r12">with</span><span class="r7"> the paragraph above, both</span><span class="r9">                                                         </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  indented relative to the bullet</span><span class="r8">.</span><span class="r9">                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  </span><span class="r8">-</span><span class="r7"> This </span><span class="r8">is</span><span class="r7"> a sublist</span><span class="r8">.</span><span class="r7">  The bullet lines up </span><span class="r12">with</span><span class="r7"> the left edge of</span><span class="r9">                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    the text blocks above</span><span class="r8">.</span><span class="r7">  A sublist </span><span class="r8">is</span><span class="r7"> a new list so requires a</span><span class="r9">                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    blank line above </span><span class="r8">and</span><span class="r7"> below</span><span class="r8">.</span><span class="r9">                                                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">-</span><span class="r7"> This </span><span class="r8">is</span><span class="r7"> the third item of the main list</span><span class="r8">.</span><span class="r9">                                                                          </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">This paragraph </span><span class="r8">is</span><span class="r7"> </span><span class="r8">not</span><span class="r7"> part of the list</span><span class="r8">.</span><span class="r9">                                                                             </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Here are examples of </span><span class="r20">incorrectly</span><span class="r4"> formatted bullet lists:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">-</span><span class="r7"> This first line </span><span class="r8">is</span><span class="r7"> fine</span><span class="r8">.</span><span class="r9">                                                                                          </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">A blank line </span><span class="r8">is</span><span class="r7"> required between list items </span><span class="r8">and</span><span class="r7"> paragraphs</span><span class="r8">.</span><span class="r9">                                                         </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">(</span><span class="r21">Warning</span><span class="r7">)</span><span class="r9">                                                                                                           </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">-</span><span class="r7"> The following line appears to be a new sublist, but it </span><span class="r8">is</span><span class="r7"> </span><span class="r8">not</span><span class="r7">:</span><span class="r9">                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  </span><span class="r8">-</span><span class="r7"> This </span><span class="r8">is</span><span class="r7"> a paragraph continuation, </span><span class="r8">not</span><span class="r7"> a sublist (since there</span><span class="r11">&#x27;s</span><span class="r9">                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    no blank line)</span><span class="r8">.</span><span class="r7">  This line </span><span class="r8">is</span><span class="r7"> also incorrectly indented</span><span class="r8">.</span><span class="r9">                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  </span><span class="r8">-</span><span class="r7"> Warnings may be issued by the implementation</span><span class="r8">.</span><span class="r9">                                                                   </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Syntax diagram:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+------+-----------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> </span><span class="r11">&quot;- &quot;</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> list item             </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+------|</span><span class="r7"> (body elements)</span><span class="r8">+</span><span class="r7">      </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">       </span><span class="r8">+-----------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                   Enumerated Lists                                                   ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree elements: </span><a class="r3" href="../doctree.html#enumerated-list">enumerated_list</a><span class="r4">, </span><a class="r3" href="../doctree.html#list-item">list_item</a><span class="r4">.</span>
+
+<span class="r4">Enumerated lists (a.k.a. &quot;ordered&quot; lists) are similar to bullet lists, but use enumerators instead of bullets.  An </span>
+<span class="r4">enumerator consists of an enumeration sequence member and formatting, followed by whitespace. The following enumeration </span>
+<span class="r4">sequences are recognized:</span>
+
+<span class="r5"> • </span>arabic numerals: 1, 2, 3, ... (no upper limit).
+<span class="r5"> • </span>uppercase alphabet characters: A, B, C, ..., Z.
+<span class="r5"> • </span>lower-case alphabet characters: a, b, c, ..., z.
+<span class="r5"> • </span>uppercase Roman numerals: I, II, III, IV, ..., MMMMCMXCIX (4999).
+<span class="r5"> • </span>lowercase Roman numerals: i, ii, iii, iv, ..., mmmmcmxcix (4999).
+<span class="r4">In addition, the auto-enumerator, &quot;#&quot;, may be used to automatically enumerate a list.  Auto-enumerated lists may begin </span>
+<span class="r4">with explicit enumeration, which sets the sequence.  Fully auto-enumerated lists use arabic numerals and begin with 1.  </span>
+<span class="r4">(Auto-enumerated lists are new in Docutils 0.3.8.)The following formatting types are recognized:</span>
+<span class="r5"> • </span>suffixed with a period: &quot;1.&quot;, &quot;A.&quot;, &quot;a.&quot;, &quot;I.&quot;, &quot;i.&quot;.
+<span class="r5"> • </span>surrounded by parentheses: &quot;(1)&quot;, &quot;(A)&quot;, &quot;(a)&quot;, &quot;(I)&quot;, &quot;(i)&quot;.
+<span class="r5"> • </span>suffixed with a right-parenthesis: &quot;1)&quot;, &quot;A)&quot;, &quot;a)&quot;, &quot;I)&quot;, &quot;i)&quot;.
+<span class="r4">While parsing an enumerated list, a new list will be started whenever:</span>
+<span class="r5"> • </span>An enumerator is encountered which does not have the same format and sequence type as the current list (e.g. &quot;1.&quot;, &quot;(
+produces two separate lists).
+<span class="r5"> • </span>The enumerators are not in sequence (e.g., &quot;1.&quot;, &quot;3.&quot; produces two separate lists).
+<span class="r4">It is recommended that the enumerator of the first list item be ordinal-1 (&quot;1&quot;, &quot;A&quot;, &quot;a&quot;, &quot;I&quot;, or &quot;i&quot;).  Although other </span>
+<span class="r4">start-values will be recognized, they may not be supported by the output format.  A level-1 [info] system message will </span>
+<span class="r4">be generated for any list beginning with a non-ordinal-1 enumerator.Lists using Roman numerals must begin with &quot;I&quot;/&quot;i&quot; </span>
+<span class="r4">or a multi-character value, such as &quot;II&quot; or &quot;XV&quot;.  Any other single-character Roman numeral (&quot;V&quot;, &quot;X&quot;, &quot;L&quot;, &quot;C&quot;, &quot;D&quot;, </span>
+<span class="r4">&quot;M&quot;) will be interpreted as a letter of the alphabet, not as a Roman numeral. Likewise, lists using letters of the </span>
+<span class="r4">alphabet may not begin with &quot;I&quot;/&quot;i&quot;, since these are recognized as Roman numeral 1.The second line of each enumerated </span>
+<span class="r4">list item is checked for validity. This is to prevent ordinary paragraphs from being mistakenly interpreted as list </span>
+<span class="r4">items, when they happen to begin with text identical to enumerators.  For example, this text is parsed as an ordinary </span>
+<span class="r4">paragraph:</span>
+
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">A</span><span class="r8">.</span><span class="r7"> Einstein was a really</span><span class="r9">                                                                                            </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">smart dude</span><span class="r8">.</span><span class="r9">                                                                                                         </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">However, ambiguity cannot be avoided if the paragraph consists of only one line.  This text is parsed as an enumerated </span>
+<span class="r4">list item:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">A</span><span class="r8">.</span><span class="r7"> Einstein was a really smart dude</span><span class="r8">.</span><span class="r9">                                                                                </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">If a single-line paragraph begins with text identical to an enumerator (&quot;A.&quot;, &quot;1.&quot;, &quot;(b)&quot;, &quot;I)&quot;, etc.), the first </span>
+<span class="r4">character will have to be escaped in order to have the line parsed as an ordinary paragraph:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">\A</span><span class="r8">.</span><span class="r7"> Einstein was a really smart dude</span><span class="r8">.</span><span class="r9">                                                                               </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Examples of nested enumerated lists:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r10">1.</span><span class="r7"> Item </span><span class="r10">1</span><span class="r7"> initial text</span><span class="r8">.</span><span class="r9">                                                                                             </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   a) Item </span><span class="r10">1</span><span class="r7">a</span><span class="r8">.</span><span class="r9">                                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   b) Item </span><span class="r10">1</span><span class="r7">b</span><span class="r8">.</span><span class="r9">                                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r10">2.</span><span class="r7"> a) Item </span><span class="r10">2</span><span class="r7">a</span><span class="r8">.</span><span class="r9">                                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   b) Item </span><span class="r10">2</span><span class="r7">b</span><span class="r8">.</span><span class="r9">                                                                                                      </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Example syntax diagram:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+-------+----------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> </span><span class="r11">&quot;1. &quot;</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> list item            </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+-------|</span><span class="r7"> (body elements)</span><span class="r8">+</span><span class="r7">     </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        </span><span class="r8">+----------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                   Definition Lists                                                   ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree elements: </span><a class="r3" href="../doctree.html#definition-list">definition_list</a><span class="r4">, </span><a class="r3" href="../doctree.html#definition-list-item">definition_list_item</a><span class="r4">, </span><a class="r3" href="../doctree.html#term">term</a><span class="r4">, </span><a class="r3" href="../doctree.html#classifier">classifier</a><span class="r4">, </span><a class="r3" href="../doctree.html#definition">definition</a><span class="r4">.</span>
+
+<span class="r4">Each definition list item contains a term, optional classifiers, and a definition.</span>
+
+<span class="r5"> • </span>A term is a simple one-line word or phrase.  Escape a leading hyphen to prevent recognition as an option list item.
+<span class="r5"> • </span>Optional classifiers may follow the term on the same line, each after an inline &quot; : &quot; (space, colon, space).  Inline 
+markup is parsed in the term line before the classifier delimiters are recognized.  A delimiter will only be recognized 
+if it appears outside of any inline markup.
+<span class="r5"> • </span>A definition is a block indented relative to the term, and may contain multiple paragraphs and other body elements.  
+There may be no blank line between a term line and a definition block (this distinguishes definition lists from block 
+quotes). Blank lines are required before the first and after the last definition list item, but are optional in-between.
+<span class="r4">Example:</span>
+
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">term </span><span class="r10">1</span><span class="r9">                                                                                                              </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    Definition </span><span class="r10">1.</span><span class="r9">                                                                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">term </span><span class="r10">2</span><span class="r9">                                                                                                              </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    Definition </span><span class="r10">2</span><span class="r7">, paragraph </span><span class="r10">1.</span><span class="r9">                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    Definition </span><span class="r10">2</span><span class="r7">, paragraph </span><span class="r10">2.</span><span class="r9">                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">term </span><span class="r10">3</span><span class="r7"> : classifier</span><span class="r9">                                                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    Definition </span><span class="r10">3.</span><span class="r9">                                                                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">term </span><span class="r10">4</span><span class="r7"> : classifier one : classifier two</span><span class="r9">                                                                            </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    Definition </span><span class="r10">4.</span><span class="r9">                                                                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">\</span><span class="r8">-</span><span class="r7">term </span><span class="r10">5</span><span class="r9">                                                                                                            </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    Without escaping, this would be an option list item</span><span class="r8">.</span><span class="r9">                                                            </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">A definition list may be used in various ways, including:</span>
+
+<span class="r5"> • </span>As a dictionary or glossary.  The term is the word itself, a classifier may be used to indicate the usage of the term
+(noun, verb, etc.), and the definition follows.
+<span class="r5"> • </span>To describe program variables.  The term is the variable name, a classifier may be used to indicate the type of the 
+variable (string, integer, etc.), and the definition describes the variable&#x27;s use in the program.  This usage of 
+definition lists supports the classifier syntax of Grouch, a system for describing and enforcing a Python object schema.
+<span class="r4">Syntax diagram:</span>
+
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+----------------------------+</span><span class="r9">                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> term [ </span><span class="r11">&quot; : &quot;</span><span class="r7"> classifier ]</span><span class="r8">*</span><span class="r7"> </span><span class="r8">|</span><span class="r9">                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+--+-------------------------+--+</span><span class="r9">                                                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r8">|</span><span class="r7"> definition                 </span><span class="r8">|</span><span class="r9">                                                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r8">|</span><span class="r7"> (body elements)</span><span class="r8">+</span><span class="r7">           </span><span class="r8">|</span><span class="r9">                                                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r8">+----------------------------+</span><span class="r9">                                                                                   </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     Field Lists                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree elements: </span><a class="r3" href="../doctree.html#field-list">field_list</a><span class="r4">, </span><a class="r3" href="../doctree.html#field">field</a><span class="r4">, </span><a class="r3" href="../doctree.html#field-name">field_name</a><span class="r4">, </span><a class="r3" href="../doctree.html#field-body">field_body</a><span class="r4">.</span>
+
+<span class="r4">Field lists are used as part of an extension syntax, such as options for </span><span class="r3">directives</span><span class="r4">, or database-like records meant for </span>
+<span class="r4">further processing.  They may also be used for two-column table-like structures resembling database records (label &amp; </span>
+<span class="r4">data pairs). Applications of reStructuredText may recognize field names and transform fields or field bodies in certain </span>
+<span class="r4">contexts.  For examples, see </span><span class="r3">Bibliographic Fields</span><span class="r4"> below, or the &quot;</span><span class="r3">image</span><span class="r4">&quot; and &quot;</span><a class="r3" href="directives.html#metadata">meta</a><span class="r4">&quot; directives in </span><span class="r3">reStructuredText </span>
+<span class="r3">Directives</span><span class="r4">.</span>
+
+<span class="r4">Field lists are mappings from </span><span class="r13">field names</span><span class="r4"> to </span><span class="r13">field bodies</span><span class="r4">, modeled on </span><span class="r3">RFC822</span><span class="r4"> headers.  A field name may consist of any </span>
+<span class="r4">characters, but colons (&quot;:&quot;) inside of field names must be backslash-escaped when followed by whitespace. Inline markup </span>
+<span class="r4">is parsed in field names, but care must be taken when using </span><span class="r3">interpreted text</span><span class="r4"> with explicit roles in field names: the </span>
+<span class="r4">role must be a suffix to the interpreted text.  Field names are case-insensitive when further processed or transformed. </span>
+<span class="r4">The field name, along with a single colon prefix and suffix, together form the field marker.  The field marker is </span>
+<span class="r4">followed by whitespace and the field body.  The field body may contain multiple body elements, indented relative to the </span>
+<span class="r4">field marker.  The first line after the field name marker determines the indentation of the field body.  For example:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">:Date: </span><span class="r10">2001</span><span class="r8">-</span><span class="r10">08</span><span class="r8">-</span><span class="r10">16</span><span class="r9">                                                                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">:Version: </span><span class="r10">1</span><span class="r9">                                                                                                         </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">:Authors: </span><span class="r8">-</span><span class="r7"> Me</span><span class="r9">                                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">          </span><span class="r8">-</span><span class="r7"> Myself</span><span class="r9">                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">          </span><span class="r8">-</span><span class="r7"> I</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">:Indentation: Since the field marker may be quite long, the second</span><span class="r9">                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r8">and</span><span class="r7"> subsequent lines of the field body do </span><span class="r8">not</span><span class="r7"> have to line up</span><span class="r9">                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r12">with</span><span class="r7"> the first line, but they must be indented relative to the</span><span class="r9">                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   field name marker, </span><span class="r8">and</span><span class="r7"> they must line up </span><span class="r12">with</span><span class="r7"> each other</span><span class="r8">.</span><span class="r9">                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">:Parameter i: integer</span><span class="r9">                                                                                               </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">The interpretation of individual words in a multi-word field name is up to the application.  The application may specify</span>
+<span class="r4">a syntax for the field name.  For example, second and subsequent words may be treated as &quot;arguments&quot;, quoted phrases may</span>
+<span class="r4">be treated as a single argument, and direct support for the &quot;name=value&quot; syntax may be added.</span>
+
+<span class="r4">Standard </span><a class="r3" href="https://www.rfc-editor.org/rfc/rfc822.txt">RFC822</a><span class="r4"> headers cannot be used for this construct because they are ambiguous.  A word followed by a colon at the</span>
+<span class="r4">beginning of a line is common in written text.  However, in well-defined contexts such as when a field list invariably </span>
+<span class="r4">occurs at the beginning of a document (PEPs and email messages), standard RFC822 headers could be used.</span>
+
+<span class="r4">Syntax diagram (simplified):</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+--------------------+----------------------+</span><span class="r9">                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> </span><span class="r11">&quot;:&quot;</span><span class="r7"> field name </span><span class="r11">&quot;:&quot;</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> field body           </span><span class="r8">|</span><span class="r9">                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+-------+------------+</span><span class="r7">                      </span><span class="r8">|</span><span class="r9">                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        </span><span class="r8">|</span><span class="r7"> (body elements)</span><span class="r8">+</span><span class="r7">                  </span><span class="r8">|</span><span class="r9">                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        </span><span class="r8">+-----------------------------------+</span><span class="r9">                                                                       </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                 Bibliographic Fields                                                 ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree elements: </span><span class="r3">docinfo</span><span class="r4">, </span><a class="r3" href="../doctree.html#address">address</a><span class="r4">, </span><a class="r3" href="../doctree.html#author">author</a><span class="r4">, </span><a class="r3" href="../doctree.html#authors">authors</a><span class="r4">, </span><a class="r3" href="../doctree.html#contact">contact</a><span class="r4">, </span><a class="r3" href="../doctree.html#copyright">copyright</a><span class="r4">, </span><a class="r3" href="../doctree.html#date">date</a><span class="r4">, </span><a class="r3" href="../doctree.html#organization">organization</a><span class="r4">, </span><a class="r3" href="../doctree.html#revision">revision</a><span class="r4">, </span><a class="r3" href="../doctree.html#status">status</a><span class="r4">, </span><a class="r3" href="../doctree.html#topic">topic</a><span class="r4">, </span>
+<a class="r3" href="../doctree.html#version">version</a><span class="r4">.</span>
+
+<span class="r4">When a field list is the first element in a document (after the document title, if there is one) , it may have its </span>
+<span class="r4">fields transformed to document bibliographic data.  This bibliographic data corresponds to the front matter of a book, </span>
+<span class="r4">such as the title page and copyright page.</span>
+
+<span class="r4">Certain registered field names (listed below) are recognized and transformed to the corresponding doctree elements, most</span>
+<span class="r4">becoming child elements of the </span><a class="r3" href="../doctree.html#docinfo">docinfo</a><span class="r4"> element.  No ordering is required of these fields, although they may be </span>
+<span class="r4">rearranged to fit the document structure, as noted.  Unless otherwise indicated below, each of the bibliographic </span>
+<span class="r4">elements&#x27; field bodies may contain a single paragraph only.  Field bodies may be checked for </span><span class="r3">RCS keywords</span><span class="r4"> and cleaned </span>
+<span class="r4">up.  Any unrecognized fields will remain as generic fields in the docinfo element.</span>
+
+<span class="r4">The registered bibliographic field names and their corresponding doctree elements are as follows:</span>
+
+    <span class="r18">    Field name  doctree element  Abstract  topic  Address  address  Author  author  Authors  authors  Contact  </span>
+<span class="r18">contact  Copyright  copyright  Date  date  Dedication  topic  Organization  organization  Revision  revision  Status  </span>
+<span class="r18">status  Version  version</span>
+
+<span class="r4">The &quot;Authors&quot; field may contain either: a single paragraph consisting of a list of authors, separated by &quot;;&quot; or &quot;,&quot; (&quot;;&quot;</span>
+<span class="r4">is checked first, so &quot;Doe, Jane; Doe, John&quot; will work.); multiple paragraphs (one per author); or a bullet list whose </span>
+<span class="r4">elements each contain a single paragraph per author. In some languages (e.g. Swedish), there is no singular/plural </span>
+<span class="r4">distinction between &quot;Author&quot; and &quot;Authors&quot;, so only an &quot;Authors&quot; field is provided, and a single name is interpreted as </span>
+<span class="r4">an &quot;Author&quot;.  If a single name contains a comma, end it with a semicolon to disambiguate: &quot;:Authors: Doe, Jane;&quot;.The </span>
+<span class="r4">&quot;Address&quot; field is for a multi-line surface mailing address. Newlines and whitespace will be preserved.The &quot;Dedication&quot; </span>
+<span class="r4">and &quot;Abstract&quot; fields may contain arbitrary body elements.  Only one of each is allowed.  They become topic elements </span>
+<span class="r4">with &quot;Dedication&quot; or &quot;Abstract&quot; titles (or language equivalents) immediately following the docinfo element.This </span>
+<span class="r4">field-name-to-element mapping can be replaced for other languages.  See the </span><a class="r3" href="https://docutils.sourceforge.io/docutils/transforms/frontmatter.py">DocInfo transform</a><span class="r4"> implementation </span>
+<span class="r4">documentation for details.Unregistered/generic fields may contain one or more paragraphs or arbitrary body elements. The</span>
+<span class="r4">field name is also used as a </span><a class="r3" href="../doctree.html#classes">&quot;classes&quot; attribute</a><span class="r4"> value after being converted into a valid identifier form.</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     RCS Keywords                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r3">Bibliographic fields</span><span class="r4"> recognized by the parser are normally checked for RCS  keywords and cleaned up .  RCS keywords may </span>
+<span class="r4">be entered into source files as &quot;$keyword$&quot;, and once stored under RCS, CVS , or SVN , they are expanded to &quot;$keyword: </span>
+<span class="r4">expansion text $&quot;. For example, a &quot;Status&quot; field will be transformed to a &quot;status&quot; element:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">:Status: </span><span class="r15">$</span><span class="r7">keyword: expansion text </span><span class="r15">$</span><span class="r9">                                                                                 </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Processed, the &quot;status&quot; element&#x27;s text will become simply &quot;expansion text&quot;.  The dollar sign delimiters and leading RCS </span>
+<span class="r4">keyword name are removed.</span>
+
+<span class="r4">The RCS keyword processing only kicks in when the field list is in bibliographic context (first non-comment construct in</span>
+<span class="r4">the document, after a document title if there is one).</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     Option Lists                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree elements: </span><a class="r3" href="../doctree.html#option-list">option_list</a><span class="r4">, </span><a class="r3" href="../doctree.html#option-list-item">option_list_item</a><span class="r4">, </span><a class="r3" href="../doctree.html#option-group">option_group</a><span class="r4">, </span><a class="r3" href="../doctree.html#option">option</a><span class="r4">, </span><a class="r3" href="../doctree.html#option-string">option_string</a><span class="r4">, </span><a class="r3" href="../doctree.html#option-argument">option_argument</a><span class="r4">, </span><a class="r3" href="../doctree.html#description">description</a><span class="r4">.</span>
+
+<span class="r4">Option lists map a program&#x27;s command-line options to descriptions documenting them.  For example:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">-</span><span class="r7">a         Output all</span><span class="r8">.</span><span class="r9">                                                                                              </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">-</span><span class="r7">b         Output both (this description </span><span class="r8">is</span><span class="r9">                                                                         </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">           quite long)</span><span class="r8">.</span><span class="r9">                                                                                             </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">-</span><span class="r7">c arg     Output just arg</span><span class="r8">.</span><span class="r9">                                                                                         </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">--</span><span class="r7">long     Output all day long</span><span class="r8">.</span><span class="r9">                                                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">-</span><span class="r7">p         This option has two paragraphs </span><span class="r8">in</span><span class="r7"> the description</span><span class="r8">.</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">           This </span><span class="r8">is</span><span class="r7"> the first</span><span class="r8">.</span><span class="r9">                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">           This </span><span class="r8">is</span><span class="r7"> the second</span><span class="r8">.</span><span class="r7">  Blank lines may be omitted between</span><span class="r9">                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">           options (</span><span class="r12">as</span><span class="r7"> above) </span><span class="r8">or</span><span class="r7"> left </span><span class="r8">in</span><span class="r7"> (</span><span class="r12">as</span><span class="r7"> here </span><span class="r8">and</span><span class="r7"> below)</span><span class="r8">.</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">--</span><span class="r7">very</span><span class="r8">-</span><span class="r7">long</span><span class="r8">-</span><span class="r7">option  A VMS</span><span class="r8">-</span><span class="r7">style option</span><span class="r8">.</span><span class="r7">  Note the adjustment </span><span class="r12">for</span><span class="r9">                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">                    the required two spaces</span><span class="r8">.</span><span class="r9">                                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">--</span><span class="r7">an</span><span class="r8">-</span><span class="r7">even</span><span class="r8">-</span><span class="r7">longer</span><span class="r8">-</span><span class="r7">option</span><span class="r9">                                                                                             </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">           The description can also start on the next line</span><span class="r8">.</span><span class="r9">                                                         </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">-</span><span class="r10">2</span><span class="r7">, </span><span class="r8">--</span><span class="r7">two  This option has two variants</span><span class="r8">.</span><span class="r9">                                                                            </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">-</span><span class="r7">f FILE, </span><span class="r8">--</span><span class="r7">file</span><span class="r8">=</span><span class="r7">FILE  These two options are synonyms; both have</span><span class="r9">                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">                      arguments</span><span class="r8">.</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">/</span><span class="r7">V         A VMS</span><span class="r8">/</span><span class="r7">DOS</span><span class="r8">-</span><span class="r7">style option</span><span class="r8">.</span><span class="r9">                                                                                  </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">There are several types of options recognized by reStructuredText:</span>
+
+<span class="r5"> • </span>Short POSIX options consist of one dash and an option letter.
+<span class="r5"> • </span>Long POSIX options consist of two dashes and an option word; some systems use a single dash.
+<span class="r5"> • </span>Old GNU-style &quot;plus&quot; options consist of one plus and an option letter (&quot;plus&quot; options are deprecated now, their use 
+discouraged).
+<span class="r5"> • </span>DOS/VMS options consist of a slash and an option letter or word.
+<span class="r4">Please note that both POSIX-style and DOS/VMS-style options may be used by DOS or Windows software.  These and other </span>
+<span class="r4">variations are sometimes used mixed together.  The names above have been chosen for convenience only.The syntax for </span>
+<span class="r4">short and long POSIX options is based on the syntax supported by Python&#x27;s </span><a class="r3" href="https://docs.python.org/3/library/getopt.html">getopt.py</a><span class="r4"> module, which implements an option </span>
+<span class="r4">parser similar to the </span><a class="r3" href="https://www.gnu.org/software/libc/manual/html_node/Getopt-Long-Options.html">GNU libc getopt_long()</a><span class="r4"> function but with some restrictions.  There are many variant option </span>
+<span class="r4">systems, and reStructuredText option lists do not support all of them.Although long POSIX and DOS/VMS option words may </span>
+<span class="r4">be allowed to be truncated by the operating system or the application when used on the command line, reStructuredText </span>
+<span class="r4">option lists do not show or support this with any special syntax.  The complete option word should be given, supported </span>
+<span class="r4">by notes about truncation if and when applicable.Options may be followed by an argument placeholder, whose role and </span>
+<span class="r4">syntax should be explained in the description text. Either a space or an equals sign may be used as a delimiter between </span>
+<span class="r4">long options and option argument placeholders; short options (&quot;-&quot; or &quot;+&quot; prefix only) use a space or omit the delimiter.</span>
+<span class="r4">Option arguments may take one of two forms:</span>
+<span class="r5"> • </span>Begins with a letter ([a-zA-Z]) and subsequently consists of letters, numbers, underscores and hyphens ([a-zA-Z0-9_-]
+<span class="r5"> • </span>Begins with an open-angle-bracket (&lt;) and ends with a close-angle-bracket (&gt;); any characters except angle brackets a
+allowed internally.
+<span class="r4">Multiple option &quot;synonyms&quot; may be listed, sharing a single description.  They must be separated by comma-space.There </span>
+<span class="r4">must be at least two spaces between the option(s) and the description (which can also start on the next line).  The </span>
+<span class="r4">description may contain multiple body elements. The first line after the option marker determines the indentation of the</span>
+<span class="r4">description.  As with other types of lists, blank lines are required before the first option list item and after the </span>
+<span class="r4">last, but are optional between option entries.Syntax diagram (simplified):</span>
+
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+----------------------------+-------------+</span><span class="r9">                                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> option [</span><span class="r11">&quot; &quot;</span><span class="r7"> argument] </span><span class="r11">&quot;  &quot;</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> description </span><span class="r8">|</span><span class="r9">                                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+-------+--------------------+</span><span class="r7">             </span><span class="r8">|</span><span class="r9">                                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        </span><span class="r8">|</span><span class="r7"> (body elements)</span><span class="r8">+</span><span class="r7">                 </span><span class="r8">|</span><span class="r9">                                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        </span><span class="r8">+----------------------------------+</span><span class="r9">                                                                        </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                    Literal Blocks                                                    ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree element: </span><a class="r3" href="../doctree.html#literal-block">literal_block</a><span class="r4">.</span>
+
+<span class="r4">A paragraph consisting of two colons (&quot;::&quot;) signifies that the following text block(s) comprise a literal block.  The </span>
+<span class="r4">literal block must either be indented or quoted (see below).  No markup processing is done within a literal block.  It </span>
+<span class="r4">is left as-is, and is typically rendered in a monospaced typeface:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">This </span><span class="r8">is</span><span class="r7"> a typical paragraph</span><span class="r8">.</span><span class="r7">  An indented literal block follows</span><span class="r8">.</span><span class="r9">                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">::</span><span class="r9">                                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r12">for</span><span class="r7"> a </span><span class="r8">in</span><span class="r7"> [</span><span class="r10">5</span><span class="r7">,</span><span class="r10">4</span><span class="r7">,</span><span class="r10">3</span><span class="r7">,</span><span class="r10">2</span><span class="r7">,</span><span class="r10">1</span><span class="r7">]:   </span><span class="r22"># this is program code, shown as-is</span><span class="r9">                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        print a</span><span class="r9">                                                                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    print </span><span class="r11">&quot;it&#x27;s...&quot;</span><span class="r9">                                                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r22"># a literal block continues until the indentation ends</span><span class="r9">                                                          </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">This text has returned to the indentation of the first paragraph,</span><span class="r9">                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">is</span><span class="r7"> outside of the literal block, </span><span class="r8">and</span><span class="r7"> </span><span class="r8">is</span><span class="r7"> therefore treated </span><span class="r12">as</span><span class="r7"> an</span><span class="r9">                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">ordinary paragraph</span><span class="r8">.</span><span class="r9">                                                                                                 </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">The paragraph containing only &quot;::&quot; will be completely removed from the output; no empty paragraph will remain.</span>
+
+<span class="r4">As a convenience, the &quot;::&quot; is recognized at the end of any paragraph. If immediately preceded by whitespace, both colons</span>
+<span class="r4">will be removed from the output (this is the &quot;partially minimized&quot; form).  When text immediately precedes the &quot;::&quot;, </span><span class="r13">one</span><span class="r4"> </span>
+<span class="r4">colon will be removed from the output, leaving only one colon visible (i.e., &quot;::&quot; will be replaced by &quot;:&quot;; this is the </span>
+<span class="r4">&quot;fully minimized&quot; form).</span>
+
+<span class="r4">In other words, these are all equivalent (please pay attention to the colons after &quot;Paragraph&quot;):</span>
+
+<span class="r5"> 1</span> Expanded form:  Paragraph:  ::      Literal block
+<span class="r5"> 2</span> Partially minimized form:  Paragraph: ::      Literal block
+<span class="r5"> 3</span> Fully minimized form:  Paragraph::      Literal block
+<span class="r4">All whitespace (including line breaks, but excluding minimum indentation for indented literal blocks) is preserved.  </span>
+<span class="r4">Blank lines are required before and after a literal block, but these blank lines are not included as part of the literal</span>
+<span class="r4">block.</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                               Indented Literal Blocks                                                ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Indented literal blocks are indicated by indentation relative to the surrounding text (leading whitespace on each line).</span>
+<span class="r4">The minimum indentation will be removed from each line of an indented literal block.  The literal block need not be </span>
+<span class="r4">contiguous; blank lines are allowed between sections of indented text.  The literal block ends with the end of the </span>
+<span class="r4">indentation.</span>
+
+<span class="r4">Syntax diagram:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+------------------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> paragraph                    </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> (ends </span><span class="r12">with</span><span class="r7"> </span><span class="r11">&quot;::&quot;</span><span class="r7">)             </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+------------------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r8">+---------------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r8">|</span><span class="r7"> indented literal block    </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r8">+---------------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                Quoted Literal Blocks                                                 ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Quoted literal blocks are unindented contiguous blocks of text where each line begins with the same non-alphanumeric </span>
+<span class="r4">printable 7-bit ASCII character .  A blank line ends a quoted literal block.  The quoting characters are preserved in </span>
+<span class="r4">the processed document.</span>
+
+<span class="r4">Possible uses include literate programming in Haskell and email quoting:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">John Doe wrote::</span><span class="r9">                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">&gt;&gt;</span><span class="r7"> Great idea</span><span class="r15">!</span><span class="r9">                                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">&gt;</span><span class="r9">                                                                                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">&gt;</span><span class="r7"> Why didn</span><span class="r11">&#x27;t I think of that?</span><span class="r9">                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">You just did</span><span class="r15">!</span><span class="r7">  ;</span><span class="r8">-</span><span class="r7">)</span><span class="r9">                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Syntax diagram:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+------------------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> paragraph                    </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> (ends </span><span class="r12">with</span><span class="r7"> </span><span class="r11">&quot;::&quot;</span><span class="r7">)             </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+------------------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+------------------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> </span><span class="r11">&quot;&gt;&quot;</span><span class="r7"> per</span><span class="r8">-</span><span class="r7">line</span><span class="r8">-</span><span class="r7">quoted          </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> </span><span class="r11">&quot;&gt;&quot;</span><span class="r7"> contiguous literal block </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+------------------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     Line Blocks                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree elements: </span><a class="r3" href="../doctree.html#line-block">line_block</a><span class="r4">, </span><a class="r3" href="../doctree.html#line">line</a><span class="r4">.  (New in Docutils 0.3.5.)</span>
+
+<span class="r4">Line blocks are useful for address blocks, verse (poetry, song lyrics), and unadorned lists, where the structure of </span>
+<span class="r4">lines is significant.  Line blocks are groups of lines beginning with vertical bar (&quot;|&quot;) prefixes.  Each vertical bar </span>
+<span class="r4">prefix indicates a new line, so line breaks are preserved.  Initial indents are also significant, resulting in a nested </span>
+<span class="r4">structure.  Inline markup is supported. Continuation lines are wrapped portions of long lines; they begin with a space </span>
+<span class="r4">in place of the vertical bar.  The left edge of a continuation line must be indented, but need not be aligned with the </span>
+<span class="r4">left edge of the text above it.  A line block ends with a blank line.</span>
+
+<span class="r4">This example illustrates continuation lines:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> Lend us a couple of bob till Thursday</span><span class="r8">.</span><span class="r9">                                                                            </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> I</span><span class="r11">&#x27;m absolutely skint.</span><span class="r9">                                                                                             </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> But I</span><span class="r11">&#x27;m expecting a postal order and I can pay you back</span><span class="r9">                                                           </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  </span><span class="r12">as</span><span class="r7"> soon </span><span class="r12">as</span><span class="r7"> it comes</span><span class="r8">.</span><span class="r9">                                                                                              </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> Love, Ewan</span><span class="r8">.</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">This example illustrates the nesting of line blocks, indicated by the initial indentation of new lines:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">Take it away, Eric the Orchestra Leader</span><span class="r15">!</span><span class="r9">                                                                            </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r8">|</span><span class="r7"> A one, two, a one two three four</span><span class="r9">                                                                              </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r8">|</span><span class="r9">                                                                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r8">|</span><span class="r7"> Half a bee, philosophically,</span><span class="r9">                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r8">|</span><span class="r7">     must, </span><span class="r8">*</span><span class="r7">ipso facto</span><span class="r8">*</span><span class="r7">, half </span><span class="r8">not</span><span class="r7"> be</span><span class="r8">.</span><span class="r9">                                                                          </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r8">|</span><span class="r7"> But half the bee has got to be,</span><span class="r9">                                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r8">|</span><span class="r7">     </span><span class="r8">*</span><span class="r7">vis a vis</span><span class="r8">*</span><span class="r7"> its entity</span><span class="r8">.</span><span class="r7">  D</span><span class="r11">&#x27;you see?</span><span class="r9">                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r8">|</span><span class="r9">                                                                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r8">|</span><span class="r7"> But can a bee be said to be</span><span class="r9">                                                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r8">|</span><span class="r7">     </span><span class="r8">or</span><span class="r7"> </span><span class="r8">not</span><span class="r7"> to be an entire bee,</span><span class="r9">                                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r8">|</span><span class="r7">         when half the bee </span><span class="r8">is</span><span class="r7"> </span><span class="r8">not</span><span class="r7"> a bee,</span><span class="r9">                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r8">|</span><span class="r7">             due to some ancient injury</span><span class="r15">?</span><span class="r9">                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r8">|</span><span class="r9">                                                                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r8">|</span><span class="r7"> Singing</span><span class="r8">...</span><span class="r9">                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Syntax diagram:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+------+-----------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> </span><span class="r11">&quot;| &quot;</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> line                  </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+------|</span><span class="r7"> continuation line     </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">       </span><span class="r8">+-----------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     Block Quotes                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree elements: </span><a class="r3" href="../doctree.html#block-quote">block_quote</a><span class="r4">, </span><a class="r3" href="../doctree.html#attribution">attribution</a><span class="r4">.</span>
+
+<span class="r4">A text block that is indented relative to the preceding text, without preceding markup indicating it to be a literal </span>
+<span class="r4">block or other content, is a block quote.  All markup processing (for body elements and inline markup) continues within </span>
+<span class="r4">the block quote:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">This </span><span class="r8">is</span><span class="r7"> an ordinary paragraph, introducing a block quote</span><span class="r8">.</span><span class="r9">                                                           </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r11">&quot;It is my business to know things.  That is my trade.&quot;</span><span class="r9">                                                          </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r8">--</span><span class="r7"> Sherlock Holmes</span><span class="r9">                                                                                              </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">A block quote may end with an attribution: a text block beginning with </span><span class="r14">--</span><span class="r4">, </span><span class="r14">---</span><span class="r4">, or a true em-dash, flush left within the</span>
+<span class="r4">block quote.  If the attribution consists of multiple lines, the left edges of the second and subsequent lines must </span>
+<span class="r4">align.</span>
+
+<span class="r4">Multiple block quotes may occur consecutively if terminated with attributions.</span>
+
+    <span class="r18">Unindented paragraph.</span>
+
+<span class="r3">Empty comments</span><span class="r4"> may be used to explicitly terminate preceding constructs that would otherwise consume a block quote:</span>
+
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">*</span><span class="r7"> List item</span><span class="r8">.</span><span class="r9">                                                                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r9">                                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    Block quote </span><span class="r10">3.</span><span class="r9">                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Empty comments may also be used to separate block quotes:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">    Block quote </span><span class="r10">4.</span><span class="r9">                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r9">                                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    Block quote </span><span class="r10">5.</span><span class="r9">                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Blank lines are required before and after a block quote, but these blank lines are not included as part of the block </span>
+<span class="r4">quote.</span>
+
+<span class="r4">Syntax diagram:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+------------------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> (current level of            </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> indentation)                 </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+------------------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r8">+---------------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r8">|</span><span class="r7"> block quote               </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r8">|</span><span class="r7"> (body elements)</span><span class="r8">+</span><span class="r7">          </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r8">|</span><span class="r7">                           </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r8">|</span><span class="r7"> </span><span class="r8">--</span><span class="r7"> attribution text       </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r8">|</span><span class="r7">    (optional)             </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r8">+---------------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                    Doctest Blocks                                                    ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree element: </span><a class="r3" href="../doctree.html#doctest-block">doctest_block</a><span class="r4">.</span>
+
+<span class="r4">Doctest blocks are interactive Python sessions cut-and-pasted into docstrings.  They are meant to illustrate usage by </span>
+<span class="r4">example, and provide an elegant and powerful testing environment via the </span><a class="r3" href="https://docs.python.org/3/library/doctest.html">doctest module</a><span class="r4"> in the Python standard library.</span>
+
+<span class="r4">Doctest blocks are text blocks which begin with </span><span class="r14">&quot;&gt;&gt;&gt; &quot;</span><span class="r4">, the Python interactive interpreter main prompt, and end with a </span>
+<span class="r4">blank line. Doctest blocks are treated as a special case of literal blocks, without requiring the literal block syntax. </span>
+<span class="r4">If both are present, the literal block syntax takes priority over Doctest block syntax:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">This </span><span class="r8">is</span><span class="r7"> an ordinary paragraph</span><span class="r8">.</span><span class="r9">                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">&gt;&gt;&gt;</span><span class="r7"> print </span><span class="r11">&#x27;this is a Doctest block&#x27;</span><span class="r9">                                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">this </span><span class="r8">is</span><span class="r7"> a Doctest block</span><span class="r9">                                                                                             </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">The following </span><span class="r8">is</span><span class="r7"> a literal block::</span><span class="r9">                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    </span><span class="r8">&gt;&gt;&gt;</span><span class="r7"> This </span><span class="r8">is</span><span class="r7"> </span><span class="r8">not</span><span class="r7"> recognized </span><span class="r12">as</span><span class="r7"> a doctest block by</span><span class="r9">                                                                </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    reStructuredText</span><span class="r8">.</span><span class="r7">  It </span><span class="r8">*</span><span class="r7">will</span><span class="r8">*</span><span class="r7"> be recognized by the doctest</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">    module, though</span><span class="r15">!</span><span class="r9">                                                                                                 </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Indentation is not required for doctest blocks.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                        Tables                                                        ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree elements: </span><a class="r3" href="../doctree.html#table">table</a><span class="r4">, </span><a class="r3" href="../doctree.html#tgroup">tgroup</a><span class="r4">, </span><a class="r3" href="../doctree.html#colspec">colspec</a><span class="r4">, </span><a class="r3" href="../doctree.html#thead">thead</a><span class="r4">, </span><a class="r3" href="../doctree.html#tbody">tbody</a><span class="r4">, </span><a class="r3" href="../doctree.html#row">row</a><span class="r4">, </span><a class="r3" href="../doctree.html#entry">entry</a><span class="r4">.</span>
+
+<span class="r4">ReStructuredText provides two syntax variants for delineating table cells: </span><span class="r3">Grid Tables</span><span class="r4"> and </span><span class="r3">Simple Tables</span><span class="r4">. Tables are </span>
+<span class="r4">also generated by the </span><a class="r3" href="directives.html#csv-table">CSV Table</a><span class="r4"> and </span><a class="r3" href="directives.html#list-table">List Table</a><span class="r4"> directives. The </span><a class="r3" href="directives.html#table">table directive</a><span class="r4"> is used to add a table title or specify </span>
+<span class="r4">options.</span>
+
+<span class="r4">As with other body elements, blank lines are required before and after tables.  Tables&#x27; left edges should align with the</span>
+<span class="r4">left edge of preceding text blocks; if indented, the table is considered to be part of a block quote.</span>
+
+<span class="r4">Once isolated, each table cell is treated as a miniature document; the top and bottom cell boundaries act as delimiting </span>
+<span class="r4">blank lines.  Each cell contains zero or more body elements.  Cell contents may include left and/or right margins, which</span>
+<span class="r4">are removed before processing.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     Grid Tables                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Grid tables provide a complete table representation via grid-like &quot;ASCII art&quot;.  Grid tables allow arbitrary cell </span>
+<span class="r4">contents (body elements), and both row and column spans.  However, grid tables can be cumbersome to produce, especially </span>
+<span class="r4">for simple data sets.  The </span><span class="r3">Emacs table mode</span><span class="r4"> is a tool that allows easy editing of grid tables, in Emacs.  See </span><span class="r3">Simple </span>
+<span class="r3">Tables</span><span class="r4"> for a simpler (but limited) representation.</span>
+
+<span class="r4">Grid tables are described with a visual grid made up of the characters &quot;-&quot;, &quot;=&quot;, &quot;|&quot;, and &quot;+&quot;.  The hyphen (&quot;-&quot;) is used</span>
+<span class="r4">for horizontal lines (row separators).  The equals sign (&quot;=&quot;) may be used to separate optional header rows from the </span>
+<span class="r4">table body (not supported by the </span><a class="r3" href="http://table.sourceforge.net/">Emacs table mode</a><span class="r4">).  The vertical bar (&quot;|&quot;) is used for vertical lines (column </span>
+<span class="r4">separators).  The plus sign (&quot;+&quot;) is used for intersections of horizontal and vertical lines.  Example:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+------------------------+------------+----------+----------+</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> Header row, column </span><span class="r10">1</span><span class="r7">   </span><span class="r8">|</span><span class="r7"> Header </span><span class="r10">2</span><span class="r7">   </span><span class="r8">|</span><span class="r7"> Header </span><span class="r10">3</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> Header </span><span class="r10">4</span><span class="r7"> </span><span class="r8">|</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> (header rows optional) </span><span class="r8">|</span><span class="r7">            </span><span class="r8">|</span><span class="r7">          </span><span class="r8">|</span><span class="r7">          </span><span class="r8">|</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+========================+============+==========+==========+</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> body row </span><span class="r10">1</span><span class="r7">, column </span><span class="r10">1</span><span class="r7">   </span><span class="r8">|</span><span class="r7"> column </span><span class="r10">2</span><span class="r7">   </span><span class="r8">|</span><span class="r7"> column </span><span class="r10">3</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> column </span><span class="r10">4</span><span class="r7"> </span><span class="r8">|</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+------------------------+------------+----------+----------+</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> body row </span><span class="r10">2</span><span class="r7">             </span><span class="r8">|</span><span class="r7"> Cells may span columns</span><span class="r8">.</span><span class="r7">          </span><span class="r8">|</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+------------------------+------------+---------------------+</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> body row </span><span class="r10">3</span><span class="r7">             </span><span class="r8">|</span><span class="r7"> Cells may  </span><span class="r8">|</span><span class="r7"> </span><span class="r8">-</span><span class="r7"> Table cells       </span><span class="r8">|</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+------------------------+</span><span class="r7"> span rows</span><span class="r8">.</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> </span><span class="r8">-</span><span class="r7"> contain           </span><span class="r8">|</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> body row </span><span class="r10">4</span><span class="r7">             </span><span class="r8">|</span><span class="r7">            </span><span class="r8">|</span><span class="r7"> </span><span class="r8">-</span><span class="r7"> body elements</span><span class="r8">.</span><span class="r7">    </span><span class="r8">|</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+------------------------+------------+---------------------+</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Some care must be taken with grid tables to avoid undesired interactions with cell text in rare cases.  For example, the</span>
+<span class="r4">following table contains a cell in row 2 spanning from column 2 to column 4:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+--------------+----------+-----------+-----------+</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> row </span><span class="r10">1</span><span class="r7">, col </span><span class="r10">1</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> column </span><span class="r10">2</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> column </span><span class="r10">3</span><span class="r7">  </span><span class="r8">|</span><span class="r7"> column </span><span class="r10">4</span><span class="r7">  </span><span class="r8">|</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+--------------+----------+-----------+-----------+</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> row </span><span class="r10">2</span><span class="r7">        </span><span class="r8">|</span><span class="r7">                                  </span><span class="r8">|</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+--------------+----------+-----------+-----------+</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> row </span><span class="r10">3</span><span class="r7">        </span><span class="r8">|</span><span class="r7">          </span><span class="r8">|</span><span class="r7">           </span><span class="r8">|</span><span class="r7">           </span><span class="r8">|</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+--------------+----------+-----------+-----------+</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">If a vertical bar is used in the text of that cell, it could have unintended effects if accidentally aligned with column</span>
+<span class="r4">boundaries:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+--------------+----------+-----------+-----------+</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> row </span><span class="r10">1</span><span class="r7">, col </span><span class="r10">1</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> column </span><span class="r10">2</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> column </span><span class="r10">3</span><span class="r7">  </span><span class="r8">|</span><span class="r7"> column </span><span class="r10">4</span><span class="r7">  </span><span class="r8">|</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+--------------+----------+-----------+-----------+</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> row </span><span class="r10">2</span><span class="r7">        </span><span class="r8">|</span><span class="r7"> Use the command </span><span class="r15">``</span><span class="r7">ls </span><span class="r8">|</span><span class="r7"> more</span><span class="r15">``</span><span class="r8">.</span><span class="r7">   </span><span class="r8">|</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+--------------+----------+-----------+-----------+</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> row </span><span class="r10">3</span><span class="r7">        </span><span class="r8">|</span><span class="r7">          </span><span class="r8">|</span><span class="r7">           </span><span class="r8">|</span><span class="r7">           </span><span class="r8">|</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+--------------+----------+-----------+-----------+</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Several solutions are possible.  All that is needed is to break the continuity of the cell outline rectangle.  One </span>
+<span class="r4">possibility is to shift the text by adding an extra space before:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+--------------+----------+-----------+-----------+</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> row </span><span class="r10">1</span><span class="r7">, col </span><span class="r10">1</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> column </span><span class="r10">2</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> column </span><span class="r10">3</span><span class="r7">  </span><span class="r8">|</span><span class="r7"> column </span><span class="r10">4</span><span class="r7">  </span><span class="r8">|</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+--------------+----------+-----------+-----------+</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> row </span><span class="r10">2</span><span class="r7">        </span><span class="r8">|</span><span class="r7">  Use the command </span><span class="r15">``</span><span class="r7">ls </span><span class="r8">|</span><span class="r7"> more</span><span class="r15">``</span><span class="r8">.</span><span class="r7">  </span><span class="r8">|</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+--------------+----------+-----------+-----------+</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> row </span><span class="r10">3</span><span class="r7">        </span><span class="r8">|</span><span class="r7">          </span><span class="r8">|</span><span class="r7">           </span><span class="r8">|</span><span class="r7">           </span><span class="r8">|</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+--------------+----------+-----------+-----------+</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Another possibility is to add an extra line to row 2:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+--------------+----------+-----------+-----------+</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> row </span><span class="r10">1</span><span class="r7">, col </span><span class="r10">1</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> column </span><span class="r10">2</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> column </span><span class="r10">3</span><span class="r7">  </span><span class="r8">|</span><span class="r7"> column </span><span class="r10">4</span><span class="r7">  </span><span class="r8">|</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+--------------+----------+-----------+-----------+</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> row </span><span class="r10">2</span><span class="r7">        </span><span class="r8">|</span><span class="r7"> Use the command </span><span class="r15">``</span><span class="r7">ls </span><span class="r8">|</span><span class="r7"> more</span><span class="r15">``</span><span class="r8">.</span><span class="r7">   </span><span class="r8">|</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7">              </span><span class="r8">|</span><span class="r7">                                  </span><span class="r8">|</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+--------------+----------+-----------+-----------+</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> row </span><span class="r10">3</span><span class="r7">        </span><span class="r8">|</span><span class="r7">          </span><span class="r8">|</span><span class="r7">           </span><span class="r8">|</span><span class="r7">           </span><span class="r8">|</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+--------------+----------+-----------+-----------+</span><span class="r9">                                                                 </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                    Simple Tables                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Simple tables provide a compact and easy to type but limited row-oriented table representation for simple data sets.  </span>
+<span class="r4">Cell contents are typically single paragraphs, although arbitrary body elements may be represented in most cells.  </span>
+<span class="r4">Simple tables allow multi-line rows (in all but the first column) and column spans, but not row spans.  See </span><span class="r3">Grid Tables</span><span class="r4"> </span>
+<span class="r4">above for a complete table representation.</span>
+
+<span class="r4">Simple tables are described with horizontal borders made up of &quot;=&quot; and &quot;-&quot; characters.  The equals sign (&quot;=&quot;) is used </span>
+<span class="r4">for top and bottom table borders, and to separate optional header rows from the table body.  The hyphen (&quot;-&quot;) is used to</span>
+<span class="r4">indicate column spans in a single row by underlining the joined columns, and may optionally be used to explicitly and/or</span>
+<span class="r4">visually separate rows.</span>
+
+<span class="r4">A simple table begins with a top border of equals signs with one or more spaces at each column boundary (two or more </span>
+<span class="r4">spaces recommended). Regardless of spans, the top border </span><span class="r13">must</span><span class="r4"> fully describe all table columns.  There must be at least </span>
+<span class="r4">two columns in the table (to differentiate it from section headers).  The top border may be followed by header rows, and</span>
+<span class="r4">the last of the optional header rows is underlined with &#x27;=&#x27;, again with spaces at column boundaries.  There may not be a</span>
+<span class="r4">blank line below the header row separator; it would be interpreted as the bottom border of the table.  The bottom </span>
+<span class="r4">boundary of the table consists of &#x27;=&#x27; underlines, also with spaces at column boundaries.  For example, here is a truth </span>
+<span class="r4">table, a three-column table with one header row and four body rows:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">=====</span><span class="r7">  </span><span class="r8">=====</span><span class="r7">  </span><span class="r8">=======</span><span class="r9">                                                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  A      B    A </span><span class="r8">and</span><span class="r7"> B</span><span class="r9">                                                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">=====</span><span class="r7">  </span><span class="r8">=====</span><span class="r7">  </span><span class="r8">=======</span><span class="r9">                                                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r12">False</span><span class="r7">  </span><span class="r12">False</span><span class="r7">  </span><span class="r12">False</span><span class="r9">                                                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r12">True</span><span class="r7">   </span><span class="r12">False</span><span class="r7">  </span><span class="r12">False</span><span class="r9">                                                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r12">False</span><span class="r7">  </span><span class="r12">True</span><span class="r7">   </span><span class="r12">False</span><span class="r9">                                                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r12">True</span><span class="r7">   </span><span class="r12">True</span><span class="r7">   </span><span class="r12">True</span><span class="r9">                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">=====</span><span class="r7">  </span><span class="r8">=====</span><span class="r7">  </span><span class="r8">=======</span><span class="r9">                                                                                               </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Underlines of &#x27;-&#x27; may be used to indicate column spans by &quot;filling in&quot; column margins to join adjacent columns.  Column </span>
+<span class="r4">span underlines must be complete (they must cover all columns) and align with established column boundaries.  Text lines</span>
+<span class="r4">containing column span underlines may not contain any other text.  A column span underline applies only to one row </span>
+<span class="r4">immediately above it.  For example, here is a table with a column span in the header:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">=====</span><span class="r7">  </span><span class="r8">=====</span><span class="r7">  </span><span class="r8">======</span><span class="r9">                                                                                                </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   Inputs     Output</span><span class="r9">                                                                                                </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">------------</span><span class="r7">  </span><span class="r8">------</span><span class="r9">                                                                                                </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  A      B    A </span><span class="r8">or</span><span class="r7"> B</span><span class="r9">                                                                                                </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">=====</span><span class="r7">  </span><span class="r8">=====</span><span class="r7">  </span><span class="r8">======</span><span class="r9">                                                                                                </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r12">False</span><span class="r7">  </span><span class="r12">False</span><span class="r7">  </span><span class="r12">False</span><span class="r9">                                                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r12">True</span><span class="r7">   </span><span class="r12">False</span><span class="r7">  </span><span class="r12">True</span><span class="r9">                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r12">False</span><span class="r7">  </span><span class="r12">True</span><span class="r7">   </span><span class="r12">True</span><span class="r9">                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r12">True</span><span class="r7">   </span><span class="r12">True</span><span class="r7">   </span><span class="r12">True</span><span class="r9">                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">=====</span><span class="r7">  </span><span class="r8">=====</span><span class="r7">  </span><span class="r8">======</span><span class="r9">                                                                                                </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Each line of text must contain spaces at column boundaries, except where cells have been joined by column spans.  Each </span>
+<span class="r4">line of text starts a new row, except when there is a blank cell in the first column.  In that case, that line of text </span>
+<span class="r4">is parsed as a continuation line.  For this reason, cells in the first column of new rows (</span><span class="r13">not</span><span class="r4"> continuation lines) </span><span class="r13">must</span><span class="r4"> </span>
+<span class="r4">contain some text; blank cells would lead to a misinterpretation (but see the tip below).  Also, this mechanism limits </span>
+<span class="r4">cells in the first column to only one line of text.  Use </span><span class="r3">grid tables</span><span class="r4"> if this limitation is unacceptable.</span>
+
+<span class="r23">╭─────────────────────────────────────────────────────── Tip:  ────────────────────────────────────────────────────────╮</span>
+<span class="r23">│ To start a new row in a simple table without text in the first column in the processed output, use one of these:  an │</span>
+<span class="r23">│ empty comment (&quot;..&quot;), which may be omitted from the processed output (see Comments below)  a backslash escape (&quot;\&quot;)  │</span>
+<span class="r23">│ followed by a space (see Escaping Mechanism above)                                                                   │</span>
+<span class="r23">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r4">Underlines of &#x27;-&#x27; may also be used to visually separate rows, even if there are no column spans.  This is especially </span>
+<span class="r4">useful in long tables, where rows are many lines long.</span>
+
+<span class="r4">Blank lines are permitted within simple tables.  Their interpretation depends on the context.  Blank lines </span><span class="r13">between</span><span class="r4"> rows </span>
+<span class="r4">are ignored. Blank lines </span><span class="r13">within</span><span class="r4"> multi-line rows may separate paragraphs or other body elements within cells.</span>
+
+<span class="r4">The rightmost column is unbounded; text may continue past the edge of the table (as indicated by the table borders).  </span>
+<span class="r4">However, it is recommended that borders be made long enough to contain the entire text.</span>
+
+<span class="r4">The following example illustrates continuation lines (row 2 consists of two lines of text, and four lines for row 3), a </span>
+<span class="r4">blank line separating paragraphs (row 3, column 2), text extending past the right edge of the table, and a new row which</span>
+<span class="r4">will have no text in the first column in the processed output (row 4):</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">=====</span><span class="r7">  </span><span class="r8">=====</span><span class="r9">                                                                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">col </span><span class="r10">1</span><span class="r7">  col </span><span class="r10">2</span><span class="r9">                                                                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">=====</span><span class="r7">  </span><span class="r8">=====</span><span class="r9">                                                                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r10">1</span><span class="r7">      Second column of row </span><span class="r10">1.</span><span class="r9">                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r10">2</span><span class="r7">      Second column of row </span><span class="r10">2.</span><span class="r9">                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">       Second line of paragraph</span><span class="r8">.</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r10">3</span><span class="r7">      </span><span class="r8">-</span><span class="r7"> Second column of row </span><span class="r10">3.</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">       </span><span class="r8">-</span><span class="r7"> Second item </span><span class="r8">in</span><span class="r7"> bullet</span><span class="r9">                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">         list (row </span><span class="r10">3</span><span class="r7">, column </span><span class="r10">2</span><span class="r7">)</span><span class="r8">.</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">\      Row </span><span class="r10">4</span><span class="r7">; column </span><span class="r10">1</span><span class="r7"> will be empty</span><span class="r8">.</span><span class="r9">                                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">=====</span><span class="r7">  </span><span class="r8">=====</span><span class="r9">                                                                                                        </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                Explicit Markup Blocks                                                ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">The explicit markup syntax is used for </span><span class="r3">footnotes</span><span class="r4">, </span><span class="r3">citations</span><span class="r4">, </span><span class="r3">hyperlink targets</span><span class="r4">, </span><span class="r3">directives</span><span class="r4">, </span><span class="r3">substitution definitions</span><span class="r4">, </span>
+<span class="r4">and </span><span class="r3">comments</span><span class="r4">.</span>
+
+<span class="r4">An explicit markup block is a text block:</span>
+
+<span class="r5"> • </span>whose first line begins with &quot;..&quot; followed by whitespace (the &quot;explicit markup start&quot;),
+<span class="r5"> • </span>whose second and subsequent lines (if any) are indented relative to the first, and
+<span class="r5"> • </span>which ends before an unindented line.
+<span class="r4">Explicit markup blocks are analogous to field list items. The maximum common indentation is always removed from the </span>
+<span class="r4">second and subsequent lines of the block body.  Therefore, if the first construct fits in one line and the indentation </span>
+<span class="r4">of the first and second constructs should differ, the first construct should not begin on the same line as the explicit </span>
+<span class="r4">markup start.Blank lines are required between explicit markup blocks and other elements, but are optional between </span>
+<span class="r4">explicit markup blocks where unambiguous.</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      Footnotes                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">See also: </span><span class="r3">Footnote References</span><span class="r4">.</span>
+
+<span class="r4">Doctree elements: </span><a class="r3" href="../doctree.html#footnote">footnote</a><span class="r4">, </span><a class="r3" href="../doctree.html#label">label</a><span class="r4">.</span>
+
+<span class="r4">Configuration settings: </span><a class="r3" href="../../user/config.html#footnote-references">footnote_references</a><span class="r4">.</span>
+
+<span class="r4">Each footnote consists of an explicit markup start (&quot;.. &quot;), a left square bracket, the footnote label, a right square </span>
+<span class="r4">bracket, and whitespace, followed by indented body elements.  A footnote label can be:</span>
+
+<span class="r5"> • </span>a whole decimal number consisting of one or more digits,
+<span class="r5"> • </span>a single &quot;#&quot; (denoting auto-numbered footnotes),
+<span class="r5"> • </span>a &quot;#&quot; followed by a simple reference name (an autonumber label), or
+<span class="r5"> • </span>a single &quot;*&quot; (denoting auto-symbol footnotes).
+<span class="r4">The footnote content (body elements) must be consistently indented and left-aligned.  The first body element within a </span>
+<span class="r4">footnote may often begin on the same line as the footnote label. However, if the first element fits on one line and the </span>
+<span class="r4">indentation of the remaining elements differ, the first element must begin on the line after the footnote label.  </span>
+<span class="r4">Otherwise, the difference in indentation will not be detected.Footnotes may occur anywhere in the document, not only at </span>
+<span class="r4">the end. Where and how they appear in the processed output depends on the processing system.Here is a manually numbered </span>
+<span class="r4">footnote:</span>
+
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> [</span><span class="r10">1</span><span class="r7">] Body elements go here</span><span class="r8">.</span><span class="r9">                                                                                       </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Each footnote automatically generates a hyperlink target pointing to itself.  The text of the hyperlink target name is </span>
+<span class="r4">the same as that of the footnote label.  </span><span class="r3">Auto-numbered footnotes</span><span class="r4"> generate a number as their footnote label and reference</span>
+<span class="r4">name.  See </span><span class="r3">Implicit Hyperlink Targets</span><span class="r4"> for a complete description of the mechanism.</span>
+
+<span class="r4">Syntax diagram:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+-------+-------------------------+</span><span class="r9">                                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> </span><span class="r11">&quot;.. &quot;</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> </span><span class="r11">&quot;[&quot;</span><span class="r7"> label </span><span class="r11">&quot;]&quot;</span><span class="r7"> footnote  </span><span class="r8">|</span><span class="r9">                                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+-------+</span><span class="r7">                         </span><span class="r8">|</span><span class="r9">                                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        </span><span class="r8">|</span><span class="r7"> (body elements)</span><span class="r8">+</span><span class="r7">        </span><span class="r8">|</span><span class="r9">                                                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        </span><span class="r8">+-------------------------+</span><span class="r9">                                                                                 </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                               Auto-Numbered Footnotes                                                ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">A number sign (&quot;#&quot;) may be used as the first character of a footnote label to request automatic numbering of the </span>
+<span class="r4">footnote or footnote reference.</span>
+
+<span class="r4">The first footnote to request automatic numbering is assigned the label &quot;1&quot;, the second is assigned the label &quot;2&quot;, and </span>
+<span class="r4">so on (assuming there are no manually numbered footnotes present; see </span><span class="r3">Mixed Manual and Auto-Numbered Footnotes</span><span class="r4"> below).  </span>
+<span class="r4">A footnote which has automatically received a label &quot;1&quot; generates an implicit hyperlink target with name &quot;1&quot;, just as if</span>
+<span class="r4">the label was explicitly specified.</span>
+
+<span class="r4">A footnote may specify a label explicitly while at the same time requesting automatic numbering: </span><span class="r14">[#label]</span><span class="r4">.  These labels</span>
+<span class="r4">are called .  Autonumber labels do two things:</span>
+
+<span class="r5"> • </span>On the footnote itself, they generate a hyperlink target whose name is the autonumber label (doesn&#x27;t include the &quot;#&quot;)
+<span class="r5"> • </span>They allow an automatically numbered footnote to be referred to more than once, as a footnote reference or hyperlink 
+reference.  For example:  If [#note]_ is the first footnote reference, it will show up as &quot;[1]&quot;.  We can refer to it 
+again as [#note]_ and again see &quot;[1]&quot;.  We can also refer to it as note_ (an ordinary internal hyperlink reference).  ..
+[#note] This is the footnote labeled &quot;note&quot;.
+<span class="r4">The numbering is determined by the order of the footnotes, not by the order of the references.  For footnote references </span>
+<span class="r4">without autonumber labels (</span><span class="r14">[#]_</span><span class="r4">), the footnotes and footnote references must be in the same relative order but need not </span>
+<span class="r4">alternate in lock-step.  For example:</span>
+
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">[</span><span class="r22">#]_ is a reference to footnote 1, and [#]_ is a reference to</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">footnote </span><span class="r10">2.</span><span class="r9">                                                                                                         </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> [</span><span class="r22">#] This is footnote 1.</span><span class="r9">                                                                                          </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> [</span><span class="r22">#] This is footnote 2.</span><span class="r9">                                                                                          </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> [</span><span class="r22">#] This is footnote 3.</span><span class="r9">                                                                                          </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">[</span><span class="r22">#]_ is a reference to footnote 3.</span><span class="r9">                                                                                  </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Special care must be taken if footnotes themselves contain auto-numbered footnote references, or if multiple references </span>
+<span class="r4">are made in close proximity.  Footnotes and references are noted in the order they are encountered in the document, </span>
+<span class="r4">which is not necessarily the same as the order in which a person would read them.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                Auto-Symbol Footnotes                                                 ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">An asterisk (&quot;*&quot;) may be used for footnote labels to request automatic symbol generation for footnotes and footnote </span>
+<span class="r4">references.  The asterisk may be the only character in the label.  For example:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">Here </span><span class="r8">is</span><span class="r7"> a symbolic footnote reference: [</span><span class="r8">*</span><span class="r7">]_</span><span class="r8">.</span><span class="r9">                                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> [</span><span class="r8">*</span><span class="r7">] This </span><span class="r8">is</span><span class="r7"> the footnote</span><span class="r8">.</span><span class="r9">                                                                                        </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">A transform will insert symbols as labels into corresponding footnotes and footnote references.  The number of </span>
+<span class="r4">references must be equal to the number of footnotes.  One symbol footnote cannot have multiple references.</span>
+
+<span class="r4">The standard Docutils system uses the following symbols for footnote marks :</span>
+
+<span class="r5"> • </span>asterisk/star (&quot;*&quot;)
+<span class="r5"> • </span>dagger (HTML character entity &quot;&amp;dagger;&quot;, Unicode U+02020)
+<span class="r5"> • </span>double dagger (&quot;&amp;Dagger;&quot;/U+02021)
+<span class="r5"> • </span>section mark (&quot;&amp;sect;&quot;/U+000A7)
+<span class="r5"> • </span>pilcrow or paragraph mark (&quot;&amp;para;&quot;/U+000B6)
+<span class="r5"> • </span>number sign (&quot;#&quot;)
+<span class="r5"> • </span>spade suit (&quot;&amp;spades;&quot;/U+02660)
+<span class="r5"> • </span>heart suit (&quot;&amp;hearts;&quot;/U+02665)
+<span class="r5"> • </span>diamond suit (&quot;&amp;diams;&quot;/U+02666)
+<span class="r5"> • </span>club suit (&quot;&amp;clubs;&quot;/U+02663)
+<span class="r4">If more than ten symbols are required, the same sequence will be reused, doubled and then tripled, and so on (&quot;**&quot; </span>
+<span class="r4">etc.).</span>
+<span class="r2">╭─────────────────────────────────────────────────────── Note:  ───────────────────────────────────────────────────────╮</span>
+<span class="r2">│ When using auto-symbol footnotes, the choice of output encoding is important.  Many of the symbols used are not      │</span>
+<span class="r2">│ encodable in certain common text encodings such as Latin-1 (ISO 8859-1).  The use of UTF-8 for the output encoding   │</span>
+<span class="r2">│ is recommended.  An alternative for HTML and XML output is to use the &quot;xmlcharrefreplace&quot; output encoding error      │</span>
+<span class="r2">│ handler.                                                                                                             │</span>
+<span class="r2">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                       Mixed Manual and Auto-Numbered Footnotes                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Manual and automatic footnote numbering may both be used within a single document, although the results may not be </span>
+<span class="r4">expected.  Manual numbering takes priority.  Only unused footnote numbers are assigned to auto-numbered footnotes.  The </span>
+<span class="r4">following example should be illustrative:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">[</span><span class="r10">2</span><span class="r7">]_ will be </span><span class="r11">&quot;2&quot;</span><span class="r7"> (manually numbered),</span><span class="r9">                                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">[</span><span class="r22">#]_ will be &quot;3&quot; (anonymous auto-numbered), and</span><span class="r9">                                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">[</span><span class="r22">#label]_ will be &quot;1&quot; (labeled auto-numbered).</span><span class="r9">                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> [</span><span class="r10">2</span><span class="r7">] This footnote </span><span class="r8">is</span><span class="r7"> labeled manually, so its number </span><span class="r8">is</span><span class="r7"> fixed</span><span class="r8">.</span><span class="r9">                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> [</span><span class="r22">#label] This autonumber-labeled footnote will be labeled &quot;1&quot;.</span><span class="r9">                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   It </span><span class="r8">is</span><span class="r7"> the first auto</span><span class="r8">-</span><span class="r7">numbered footnote </span><span class="r8">and</span><span class="r7"> no other footnote</span><span class="r9">                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r12">with</span><span class="r7"> label </span><span class="r11">&quot;1&quot;</span><span class="r7"> exists</span><span class="r8">.</span><span class="r7">  The order of the footnotes </span><span class="r8">is</span><span class="r7"> used to</span><span class="r9">                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   determine numbering, </span><span class="r8">not</span><span class="r7"> the order of the footnote references</span><span class="r8">.</span><span class="r9">                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> [</span><span class="r22">#] This footnote will be labeled &quot;3&quot;.  It is the second</span><span class="r9">                                                         </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   auto</span><span class="r8">-</span><span class="r7">numbered footnote, but footnote label </span><span class="r11">&quot;2&quot;</span><span class="r7"> </span><span class="r8">is</span><span class="r7"> already used</span><span class="r8">.</span><span class="r9">                                                  </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      Citations                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">See also: </span><span class="r3">Citation References</span><span class="r4">.</span>
+
+<span class="r4">Doctree element: </span><a class="r3" href="../doctree.html#citation">citation</a>
+
+<span class="r4">Citations are identical to footnotes except that they use only non-numeric labels such as </span><span class="r14">[note]</span><span class="r4"> or </span><span class="r14">[GVR2001]</span><span class="r4">.  Citation</span>
+<span class="r4">labels are simple </span><span class="r3">reference names</span><span class="r4"> (case-insensitive single words consisting of alphanumerics plus internal hyphens, </span>
+<span class="r4">underscores, and periods; no whitespace).  Citations may be rendered separately and differently from footnotes.  For </span>
+<span class="r4">example:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">Here </span><span class="r8">is</span><span class="r7"> a citation reference: [CIT2002]_</span><span class="r8">.</span><span class="r9">                                                                           </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> [CIT2002] This </span><span class="r8">is</span><span class="r7"> the citation</span><span class="r8">.</span><span class="r7">  It</span><span class="r11">&#x27;s just like a footnote,</span><span class="r9">                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r12">except</span><span class="r7"> the label </span><span class="r8">is</span><span class="r7"> textual</span><span class="r8">.</span><span class="r9">                                                                                     </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                  Hyperlink Targets                                                   ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree element: </span><span class="r3">target</span><span class="r4">.</span>
+
+<span class="r4">These are also called , to differentiate them from </span><span class="r3">implicit hyperlink targets</span><span class="r4"> defined below.</span>
+
+<span class="r4">Hyperlink targets identify a location within or outside of a document, which may be linked to by </span><span class="r3">hyperlink references</span><span class="r4">.</span>
+
+<span class="r4">Hyperlink targets may be named or anonymous.  Named hyperlink targets consist of an explicit markup start (&quot;.. &quot;), an </span>
+<span class="r4">underscore, the reference name (no trailing underscore), a colon, whitespace, and a link block:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> _hyperlink</span><span class="r8">-</span><span class="r7">name: link</span><span class="r8">-</span><span class="r7">block</span><span class="r9">                                                                                      </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Reference names are whitespace-neutral and case-insensitive.  See </span><span class="r3">Reference Names</span><span class="r4"> for details and examples.</span>
+
+<span class="r4">Anonymous hyperlink targets consist of an explicit markup start (&quot;.. &quot;), two underscores, a colon, whitespace, and a </span>
+<span class="r4">link block; there is no reference name:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> __: anonymous</span><span class="r8">-</span><span class="r7">hyperlink</span><span class="r8">-</span><span class="r7">target</span><span class="r8">-</span><span class="r7">link</span><span class="r8">-</span><span class="r7">block</span><span class="r9">                                                                        </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">An alternate syntax for anonymous hyperlinks consists of two underscores, a space, and a link block:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">__ anonymous</span><span class="r8">-</span><span class="r7">hyperlink</span><span class="r8">-</span><span class="r7">target</span><span class="r8">-</span><span class="r7">link</span><span class="r8">-</span><span class="r7">block</span><span class="r9">                                                                            </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">See </span><span class="r3">Anonymous Hyperlinks</span><span class="r4"> below.</span>
+
+<span class="r4">There are three types of hyperlink targets: internal, external, and indirect.</span>
+
+<span class="r5"> 1</span> Internal hyperlink targets have empty link blocks.  They provide an end point allowing a hyperlink to connect one pla
+to another within a document.  An internal hyperlink target points to the element following the target.   For example:  
+Clicking on this internal hyperlink will take us to the target_ below.  .. _target:  The hyperlink target above points 
+to this paragraph.  Internal hyperlink targets may be &quot;chained&quot;.  Multiple adjacent internal hyperlink targets all point
+to the same element:  .. _target1: .. _target2:  The targets &quot;target1&quot; and &quot;target2&quot; are synonyms; they both point to 
+this paragraph.  If the element &quot;pointed to&quot; is an external hyperlink target (with a URI in its link block; see #2 
+below) the URI from the external hyperlink target is propagated to the internal hyperlink targets; they will all &quot;point 
+to&quot; the same URI.  There is no need to duplicate a URI.  For example, all three of the following hyperlink targets refer
+to the same URI:  .. _Python DOC-SIG mailing list archive: .. _archive: .. _Doc-SIG: 
+https://mail.python.org/pipermail/doc-sig/  An inline form of internal hyperlink target is available; see Inline 
+Internal Targets.  Works also, if the internal hyperlink target is &quot;nested&quot; at the end of an indented text block. This 
+behaviour allows setting targets to individual list items (except the first, as a preceding internal target applies to 
+the list as a whole):  * bullet list    .. _`second item`:  * second item, with hyperlink target.
+<span class="r5"> 2</span> External hyperlink targets have an absolute or relative URI or email address in their link blocks.  For example, take
+the following input:  See the Python_ home page for info.  `Write to me`_ with your questions.  .. _Python: 
+https://www.python.org .. _Write to me: jdoe@example.com  After processing into HTML, the hyperlinks might be expressed 
+as:  See the &lt;a href=&quot;https://www.python.org&quot;&gt;Python&lt;/a&gt; home page for info.  &lt;a href=&quot;mailto:jdoe@example.com&quot;&gt;Write to
+me&lt;/a&gt; with your questions.  An external hyperlink&#x27;s URI may begin on the same line as the explicit markup start and 
+target name, or it may begin in an indented text block immediately following, with no intervening blank lines.  If there
+are multiple lines in the link block, they are concatenated.  Any unescaped whitespace is removed (whitespace is 
+permitted to allow for line wrapping).  The following external hyperlink targets are equivalent:  .. _one-liner: 
+https://docutils.sourceforge.io/rst.html  .. _starts-on-this-line: https://    docutils.sourceforge.net/rst.html  .. 
+_entirely-below:    https://docutils.    sourceforge.net/rst.html  Escaped whitespace is preserved as intentional 
+spaces, e.g.:  .. _reference: ../local\ path\ with\ spaces.html  If an external hyperlink target&#x27;s URI contains an 
+underscore as its last character, it must be escaped to avoid being mistaken for an indirect hyperlink target:  This 
+link_ refers to a file called ``underscore_``.  .. _link: underscore\_  It is possible (although not generally 
+recommended) to include URIs directly within hyperlink references.  See Embedded URIs and Aliases below.
+<span class="r5"> 3</span> Indirect hyperlink targets have a hyperlink reference in their link blocks.  In the following example, target &quot;one&quot; 
+indirectly references whatever target &quot;two&quot; references, and target &quot;two&quot; references target &quot;three&quot;, an internal 
+hyperlink target.  In effect, all three reference the same thing:  .. _one: two_ .. _two: three_ .. _three:  Just as 
+with hyperlink references anywhere else in a document, if a phrase-reference is used in the link block it must be 
+enclosed in backquotes.  As with external hyperlink targets, the link block of an indirect hyperlink target may begin on
+the same line as the explicit markup start or the next line.  It may also be split over multiple lines, in which case 
+the lines are joined with whitespace before being normalized.  For example, the following indirect hyperlink targets are
+equivalent:  .. _one-liner: `A HYPERLINK`_ .. _entirely-below:    `a    hyperlink`_ .. _split: `A    Hyperlink`_  It is 
+possible to include an alias directly within hyperlink references. See Embedded URIs and Aliases below.
+<span class="r4">If the reference name contains any colons, either:</span>
+<span class="r5"> • </span>the phrase must be enclosed in backquotes:  .. _`FAQTS: Computers: Programming: Languages: Python`:    
+http://python.faqts.com/
+<span class="r5"> • </span>or the colon(s) must be backslash-escaped in the link target:  .. _Chapter One\: &quot;Tadpole Days&quot;:  It&#x27;s not easy being
+green...
+<span class="r4">See </span><span class="r3">Implicit Hyperlink Targets</span><span class="r4"> below for the resolution of duplicate reference names.Syntax diagram:</span>
+
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+-------+----------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> </span><span class="r11">&quot;.. &quot;</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> </span><span class="r11">&quot;_&quot;</span><span class="r7"> name </span><span class="r11">&quot;:&quot;</span><span class="r7"> link    </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+-------+</span><span class="r7"> block                </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        </span><span class="r8">|</span><span class="r7">                      </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        </span><span class="r8">+----------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                 Anonymous Hyperlinks                                                 ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">The </span><a class="r3" href="https://www.w3.org/">World Wide Web Consortium</a><span class="r4"> recommends in its </span><a class="r3" href="https://www.w3.org/TR/WCAG10-HTML-TECHS/#link-text">HTML Techniques for Web Content Accessibility Guidelines</a><span class="r4"> that authors </span>
+<span class="r4">should &quot;clearly identify the target of each link.&quot;  Hyperlink references should be as verbose as possible, but </span>
+<span class="r4">duplicating a verbose hyperlink name in the target is onerous and error-prone.  Anonymous hyperlinks are designed to </span>
+<span class="r4">allow convenient verbose hyperlink references, and are analogous to </span><span class="r3">Auto-Numbered Footnotes</span><span class="r4">.  They are particularly </span>
+<span class="r4">useful in short or one-off documents.  However, this feature is easily abused and can result in unreadable plaintext </span>
+<span class="r4">and/or unmaintainable documents.  Caution is advised.</span>
+
+<span class="r4">Anonymous </span><span class="r3">hyperlink references</span><span class="r4"> are specified with two underscores instead of one:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">See </span><span class="r15">`</span><span class="r7">the web site of my favorite programming language</span><span class="r15">`</span><span class="r7">__</span><span class="r8">.</span><span class="r9">                                                           </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Anonymous targets begin with &quot;.. __:&quot;; no reference name is required or allowed:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> __: https:</span><span class="r8">//</span><span class="r7">www</span><span class="r8">.</span><span class="r7">python</span><span class="r8">.</span><span class="r7">org</span><span class="r9">                                                                                       </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">As a convenient alternative, anonymous targets may begin with &quot;__&quot; only:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">__ https:</span><span class="r8">//</span><span class="r7">www</span><span class="r8">.</span><span class="r7">python</span><span class="r8">.</span><span class="r7">org</span><span class="r9">                                                                                           </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">The reference name of the reference is not used to match the reference to its target.  Instead, the order of anonymous </span>
+<span class="r4">hyperlink references and targets within the document is significant: the first anonymous reference will link to the </span>
+<span class="r4">first anonymous target.  The number of anonymous hyperlink references in a document must match the number of anonymous </span>
+<span class="r4">targets.  For readability, it is recommended that targets be kept close to references.  Take care when editing text </span>
+<span class="r4">containing anonymous references; adding, removing, and rearranging references require attention to the order of </span>
+<span class="r4">corresponding targets.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                      Directives                                                      ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree elements: depend on the directive.</span>
+
+<span class="r4">Directives are an extension mechanism for reStructuredText, a way of adding support for new constructs without adding </span>
+<span class="r4">new primary syntax (directives may support additional syntax locally).  All standard directives (those implemented and </span>
+<span class="r4">registered in the reference reStructuredText parser) are described in the </span><span class="r3">reStructuredText Directives</span><span class="r4"> document, and are </span>
+<span class="r4">always available.  Any other directives are domain-specific, and may require special action to make them available when </span>
+<span class="r4">processing the document.</span>
+
+<span class="r4">For example, here&#x27;s how an </span><span class="r3">image</span><span class="r4"> may be placed:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> image:: mylogo</span><span class="r8">.</span><span class="r7">jpeg</span><span class="r9">                                                                                              </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">A </span><a class="r3" href="directives.html#figure">figure</a><span class="r4"> (a graphic with a caption) may placed like this:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> figure:: larch</span><span class="r8">.</span><span class="r7">png</span><span class="r9">                                                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   The larch</span><span class="r8">.</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">An </span><a class="r3" href="directives.html#admonitions">admonition</a><span class="r4"> (note, caution, etc.) contains other body elements:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> note:: This </span><span class="r8">is</span><span class="r7"> a paragraph</span><span class="r9">                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r8">-</span><span class="r7"> Here </span><span class="r8">is</span><span class="r7"> a bullet list</span><span class="r8">.</span><span class="r9">                                                                                         </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Directives are indicated by an explicit markup start (&quot;.. &quot;) followed by the directive type, two colons, and whitespace </span>
+<span class="r4">(together called the &quot;directive marker&quot;).  Directive types are case-insensitive single words (alphanumerics plus </span>
+<span class="r4">isolated internal hyphens, underscores, plus signs, colons, and periods; no whitespace).  Two colons are used after the </span>
+<span class="r4">directive type for these reasons:</span>
+
+<span class="r5"> • </span>Two colons are distinctive, and unlikely to be used in common text.
+<span class="r5"> • </span>Two colons avoids clashes with common comment text like:  .. Danger: modify at your own risk!
+<span class="r5"> • </span>If an implementation of reStructuredText does not recognize a directive (i.e., the directive-handler is not installed
+a level-3 (error) system message is generated, and the entire directive block (including the directive itself) will be 
+included as a literal block.  Thus &quot;::&quot; is a natural choice.
+<span class="r4">The directive block consists of any text on the first line of the directive after the directive marker, and any </span>
+<span class="r4">subsequent indented text.  The interpretation of the directive block is up to the directive code.  There are three </span>
+<span class="r4">logical parts to the directive block:</span>
+<span class="r5"> 1</span> Directive arguments.
+<span class="r5"> 2</span> Directive options.
+<span class="r5"> 3</span> Directive content.
+<span class="r4">Individual directives can employ any combination of these parts. Directive arguments can be filesystem paths, URLs, </span>
+<span class="r4">title text, etc. Directive options are indicated using </span><span class="r3">field lists</span><span class="r4">; the field names and contents are directive-specific.</span>
+<span class="r4">Arguments and options must form a contiguous block beginning on the first or second line of the directive; a blank line </span>
+<span class="r4">indicates the beginning of the directive content block.  If either arguments and/or options are employed by the </span>
+<span class="r4">directive, a blank line must separate them from the directive content. The &quot;figure&quot; directive employs all three parts:</span>
+
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> figure:: larch</span><span class="r8">.</span><span class="r7">png</span><span class="r9">                                                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   :scale: </span><span class="r10">50</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   The larch</span><span class="r8">.</span><span class="r9">                                                                                                       </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Simple directives may not require any content.  If a directive that does not employ a content block is followed by </span>
+<span class="r4">indented text anyway, it is an error.  If a block quote should immediately follow a directive, use an empty comment </span>
+<span class="r4">in-between (see </span><span class="r3">Comments</span><span class="r4"> below).</span>
+
+<span class="r4">Actions taken in response to directives and the interpretation of text in the directive content block or subsequent text</span>
+<span class="r4">block(s) are directive-dependent.  See </span><a class="r3" href="directives.html">reStructuredText Directives</a><span class="r4"> for details.</span>
+
+<span class="r4">Directives are meant for the arbitrary processing of their contents, which can be transformed into something possibly </span>
+<span class="r4">unrelated to the original text.  It may also be possible for directives to be used as pragmas, to modify the behavior of</span>
+<span class="r4">the parser, such as to experiment with alternate syntax.  There is no parser support for this functionality at present; </span>
+<span class="r4">if a reasonable need for pragma directives is found, they may be supported.</span>
+
+<span class="r4">Directives do not generate &quot;directive&quot; elements; they are a </span><span class="r13">parser construct</span><span class="r4"> only, and have no intrinsic meaning outside</span>
+<span class="r4">of reStructuredText.  Instead, the parser will transform recognized directives into (possibly specialized) document </span>
+<span class="r4">elements.  Unknown directives will trigger level-3 (error) system messages.</span>
+
+<span class="r4">Syntax diagram:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+-------+-------------------------------+</span><span class="r9">                                                                           </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> </span><span class="r11">&quot;.. &quot;</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> directive type </span><span class="r11">&quot;::&quot;</span><span class="r7"> directive </span><span class="r8">|</span><span class="r9">                                                                           </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+-------+</span><span class="r7"> block                         </span><span class="r8">|</span><span class="r9">                                                                           </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        </span><span class="r8">|</span><span class="r7">                               </span><span class="r8">|</span><span class="r9">                                                                           </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        </span><span class="r8">+-------------------------------+</span><span class="r9">                                                                           </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                               Substitution Definitions                                               ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree element: </span><a class="r3" href="../doctree.html#substitution-definition">substitution_definition</a><span class="r4">.</span>
+
+<span class="r4">Substitution definitions are indicated by an explicit markup start (&quot;.. &quot;) followed by a vertical bar, the substitution </span>
+<span class="r4">text, another vertical bar, whitespace, and the definition block.  Substitution text may not begin or end with </span>
+<span class="r4">whitespace.  A substitution definition block contains an embedded inline-compatible directive (without the leading &quot;.. </span>
+<span class="r4">&quot;), such as &quot;</span><a class="r3" href="directives.html#image">image</a><span class="r4">&quot; or &quot;</span><a class="r3" href="directives.html#replace">replace</a><span class="r4">&quot;.  For example:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">The </span><span class="r8">|</span><span class="r7">biohazard</span><span class="r8">|</span><span class="r7"> symbol must be used on containers used to</span><span class="r9">                                                           </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">dispose of medical waste</span><span class="r8">.</span><span class="r9">                                                                                           </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> </span><span class="r8">|</span><span class="r7">biohazard</span><span class="r8">|</span><span class="r7"> image:: biohazard</span><span class="r8">.</span><span class="r7">png</span><span class="r9">                                                                                </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">It is an error for a substitution definition block to directly or indirectly contain a circular substitution reference.</span>
+
+<span class="r3">Substitution references</span><span class="r4"> are replaced in-line by the processed contents of the corresponding definition (linked by </span>
+<span class="r4">matching substitution text).  Matches are case-sensitive but forgiving; if no exact match is found, a case-insensitive </span>
+<span class="r4">comparison is attempted.</span>
+
+<span class="r4">Substitution definitions allow the power and flexibility of block-level </span><span class="r3">directives</span><span class="r4"> to be shared by inline text.  They </span>
+<span class="r4">are a way to include arbitrarily complex inline structures within text, while keeping the details out of the flow of </span>
+<span class="r4">text.  They are the equivalent of SGML/XML&#x27;s named entities or programming language macros.</span>
+
+<span class="r4">Without the substitution mechanism, every time someone wants an application-specific new inline structure, they would </span>
+<span class="r4">have to petition for a syntax change.  In combination with existing directive syntax, any inline structure can be coded </span>
+<span class="r4">without new syntax (except possibly a new directive).</span>
+
+<span class="r4">Syntax diagram:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+-------+-----------------------------------------------------+</span><span class="r9">                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> </span><span class="r11">&quot;.. &quot;</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> </span><span class="r11">&quot;|&quot;</span><span class="r7"> substitution text </span><span class="r11">&quot;| &quot;</span><span class="r7"> directive type </span><span class="r11">&quot;::&quot;</span><span class="r7"> data </span><span class="r8">|</span><span class="r9">                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+-------+</span><span class="r7"> directive block                                     </span><span class="r8">|</span><span class="r9">                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        </span><span class="r8">|</span><span class="r7">                                                     </span><span class="r8">|</span><span class="r9">                                                     </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        </span><span class="r8">+-----------------------------------------------------+</span><span class="r9">                                                     </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Following are some use cases for the substitution mechanism.  Please note that most of the embedded directives shown are</span>
+<span class="r4">examples only and have not been implemented.</span>
+
+<span class="r24">Objects</span>
+    Substitution references may be used to associate ambiguous text with a unique object identifier.  For example, many 
+sites may wish to implement an inline &quot;user&quot; directive:  |Michael| and |Jon| are our widget-wranglers.  .. |Michael| 
+user:: mjones .. |Jon|     user:: jhl  Depending on the needs of the site, this may be used to index the document for 
+later searching, to hyperlink the inline text in various ways (mailto, homepage, mouseover Javascript with profile and 
+contact information, etc.), or to customize presentation of the text (include username in the inline text, include an 
+icon image with a link next to the text, make the text bold or a different color, etc.).  The same approach can be used 
+in documents which frequently refer to a particular type of objects with unique identifiers but ambiguous common names. 
+Movies, albums, books, photos, court cases, and laws are possible.  For example:  |The Transparent Society| offers a 
+fascinating alternate view on privacy issues.  .. |The Transparent Society| book:: isbn=0738201448  Classes or 
+functions, in contexts where the module or class names are unclear and/or interpreted text cannot be used, are another 
+possibility:  4XSLT has the convenience method |runString|, so you don&#x27;t have to mess with DOM objects if all you want 
+is the transformed output.  .. |runString| function:: module=xml.xslt class=Processor
+      
+<span class="r24">Images</span>
+    Images are a common use for substitution references:  West led the |H| 3, covered by dummy&#x27;s |H| Q, East&#x27;s |H| K, 
+and trumped in hand with the |S| 2.  .. |H| image:: /images/heart.png    :height: 11    :width: 11 .. |S| image:: 
+/images/spade.png    :height: 11    :width: 11  * |Red light| means stop. * |Green light| means go. * |Yellow light| 
+means go really fast.  .. |Red light|    image:: red_light.png .. |Green light|  image:: green_light.png .. |Yellow 
+light| image:: yellow_light.png  |-&gt;&lt;-| is the official symbol of POEE_.  .. |-&gt;&lt;-| image:: discord.png .. _POEE: 
+http://www.poee.org/  The &quot;image&quot; directive has been implemented.
+      
+<span class="r24">Styles </span>
+    Substitution references may be used to associate inline text with an externally defined presentation style:  Even 
+|the text in Texas| is big.  .. |the text in Texas| style:: big  The style name may be meaningful in the context of some
+particular output format (CSS class name for HTML output, LaTeX style name for LaTeX, etc), or may be ignored for other 
+output formats (such as plaintext).  @@@ This needs to be rethought &amp; rewritten or removed:  Interpreted text is 
+unsuitable for this purpose because the set of style names cannot be predefined - it is the domain of the content 
+author, not the author of the parser and output formatter - and there is no way to associate a style name argument with 
+an interpreted text style role.  Also, it may be desirable to use the same mechanism for styling blocks::      .. 
+style:: motto        At Bob&#x27;s Underwear Shop, we&#x27;ll do anything to get in        your pants.      .. style:: disclaimer 
+All rights reversed.  Reprint what you like.  There may be sufficient need for a &quot;style&quot; mechanism to warrant simpler 
+syntax such as an extension to the interpreted text role syntax.  The substitution mechanism is cumbersome for simple 
+text styling.
+      
+<span class="r24">Templates</span>
+    Inline markup may be used for later processing by a template engine.  For example, a Zope author might write:  
+Welcome back, |name|!  .. |name| tal:: replace user/getUserName  After processing, this ZPT output would result:  
+Welcome back, &lt;span tal:replace=&quot;user/getUserName&quot;&gt;name&lt;/span&gt;!  Zope would then transform this to something like 
+&quot;Welcome back, David!&quot; during a session with an actual user.
+      
+<span class="r24">Replacement text</span>
+    The substitution mechanism may be used for simple macro substitution.  This may be appropriate when the replacement 
+text is repeated many times throughout one or more documents, especially if it may need to change later.  A short 
+example is unavoidably contrived:  |RST|_ is a little annoying to type over and over, especially when writing about 
+|RST| itself, and spelling out the bicapitalized word |RST| every time isn&#x27;t really necessary for |RST| source 
+readability.  .. |RST| replace:: reStructuredText .. _RST: https://docutils.sourceforge.io/rst.html  Note the trailing 
+underscore in the first use of a substitution reference.  This indicates a reference to the corresponding hyperlink 
+target.  Substitution is also appropriate when the replacement text cannot be represented using other inline constructs,
+or is obtrusively long:  But still, that&#x27;s nothing compared to a name like |j2ee-cas|__.  .. |j2ee-cas| replace::    the
+Java `TM`:super: 2 Platform, Enterprise Edition Client    Access Services __ 
+http://developer.java.sun.com/developer/earlyAccess/    j2eecas/  The &quot;replace&quot; directive has been implemented.
+      
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                       Comments                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree element: </span><a class="r3" href="../doctree.html#comment">comment</a><span class="r4">.</span>
+
+<span class="r3">Explicit markup blocks</span><span class="r4"> that are not recognized as </span><span class="r3">citations</span><span class="r4">, </span><span class="r3">directives</span><span class="r4">, </span><span class="r3">footnotes</span><span class="r4">, </span><span class="r3">hyperlink targets</span><span class="r4">, or </span><span class="r3">substitution </span>
+<span class="r3">definitions</span><span class="r4"> will be processed as a comment element. Arbitrary indented text may be used on the lines following the </span>
+<span class="r4">explicit markup start. To ensure that none of the other explicit markup constructs is recognized, leave the &quot;..&quot; on a </span>
+<span class="r4">line by itself:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> This </span><span class="r8">is</span><span class="r7"> a comment</span><span class="r9">                                                                                                </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r9">                                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   _so: </span><span class="r8">is</span><span class="r7"> this</span><span class="r15">!</span><span class="r9">                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r9">                                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   [</span><span class="r8">and</span><span class="r7">] this</span><span class="r15">!</span><span class="r9">                                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r9">                                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   this:: too</span><span class="r15">!</span><span class="r9">                                                                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r9">                                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">   </span><span class="r8">|</span><span class="r7">even</span><span class="r8">|</span><span class="r7"> this:: </span><span class="r15">!</span><span class="r9">                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> [this] however, </span><span class="r8">is</span><span class="r7"> a citation</span><span class="r8">.</span><span class="r9">                                                                                   </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Apart from removing the maximum common indentation, no further processing is done on the content; a comment contains a </span>
+<span class="r4">single &quot;text blob&quot;.  Depending on the output formatter, comments may be removed from the processed output.</span>
+
+<span class="r4">Syntax diagram:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">+-------+----------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">|</span><span class="r7"> </span><span class="r11">&quot;.. &quot;</span><span class="r7"> </span><span class="r8">|</span><span class="r7"> comment              </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">+-------+</span><span class="r7"> block                </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        </span><span class="r8">|</span><span class="r7">                      </span><span class="r8">|</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">        </span><span class="r8">+----------------------+</span><span class="r9">                                                                                    </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                    Empty Comments                                                    ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">An explicit markup start followed by a blank line and nothing else (apart from whitespace) is an &quot;&quot;.  It serves to </span>
+<span class="r4">terminate a preceding construct, and does </span><span class="r20">not</span><span class="r4"> consume any indented text following.  To have a block quote follow a list </span>
+<span class="r4">or any indented construct, insert an unindented empty comment in-between:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">This </span><span class="r8">is</span><span class="r9">                                                                                                             </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  a definition list</span><span class="r8">.</span><span class="r9">                                                                                                </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r9">                                                                                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">  This </span><span class="r8">is</span><span class="r7"> a block quote</span><span class="r8">.</span><span class="r9">                                                                                            </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                              Implicit Hyperlink Targets                                              ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Implicit hyperlink targets are generated by section titles, footnotes, and citations, and may also be generated by </span>
+<span class="r4">extension constructs. Implicit hyperlink targets otherwise behave identically to explicit </span><span class="r3">hyperlink targets</span><span class="r4">.</span>
+
+<span class="r4">Problems of ambiguity due to conflicting duplicate implicit and explicit reference names are avoided by following this </span>
+<span class="r4">procedure:</span>
+
+<span class="r5"> 1</span> Explicit hyperlink targets override any implicit targets having the same reference name.  The implicit hyperlink targ
+are removed, and level-1 (info) system messages are inserted.
+<span class="r5"> 2</span> Duplicate implicit hyperlink targets are removed, and level-1 (info) system messages inserted.  For example, if two o
+more sections have the same title (such as &quot;Introduction&quot; subsections of a rigidly-structured document), there will be 
+duplicate implicit hyperlink targets.
+<span class="r5"> 3</span> Duplicate explicit hyperlink targets are removed, and level-2 (warning) system messages are inserted.  Exception: 
+duplicate external hyperlink targets (identical hyperlink names and referenced URIs) do not conflict, and are not 
+removed.
+<span class="r4">System messages are inserted where target links have been removed. See &quot;Error Handling&quot; in </span><span class="r3">PEP 258</span><span class="r4">.The parser must </span>
+<span class="r4">return a set of </span><span class="r25">unique</span><span class="r4"> hyperlink targets.  The calling software (such as the </span><a class="r3" href="https://docutils.sourceforge.io/">Docutils</a><span class="r4">) can warn of unresolvable links, </span>
+<span class="r4">giving reasons for the messages.</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                    Inline Markup                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">In reStructuredText, inline markup applies to words or phrases within a text block.  The same whitespace and punctuation</span>
+<span class="r4">that serves to delimit words in written text is used to delimit the inline markup syntax constructs (see the </span><span class="r3">inline </span>
+<span class="r3">markup recognition rules</span><span class="r4"> for details).  The text within inline markup may not begin or end with whitespace.  Arbitrary </span>
+<span class="r3">character-level inline markup</span><span class="r4"> is supported although not encouraged.  Inline markup cannot be nested.</span>
+
+<span class="r4">There are nine inline markup constructs.  Five of the constructs use identical start-strings and end-strings to indicate</span>
+<span class="r4">the markup:</span>
+
+<span class="r5"> • </span>emphasis: &quot;*&quot;
+<span class="r5"> • </span>strong emphasis: &quot;**&quot;
+<span class="r5"> • </span>interpreted text: &quot;`&quot;
+<span class="r5"> • </span>inline literals: &quot;``&quot;
+<span class="r5"> • </span>substitution references: &quot;|&quot;
+<span class="r4">Three constructs use different start-strings and end-strings:</span>
+<span class="r5"> • </span>inline internal targets: &quot;_`&quot; and &quot;`&quot;
+<span class="r5"> • </span>footnote references: &quot;[&quot; and &quot;]_&quot;
+<span class="r5"> • </span>hyperlink references: &quot;`&quot; and &quot;`_&quot; (phrases), or just a trailing &quot;_&quot; (single words)
+<span class="r3">Standalone hyperlinks</span><span class="r4"> are recognized implicitly, and use no extra markup.Inline comments are not supported.</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                           Inline markup recognition rules                                            ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Inline markup start-strings and end-strings are only recognized if the following conditions are met:</span>
+
+<span class="r5"> 1</span> Inline markup start-strings must be immediately followed by non-whitespace.
+<span class="r5"> 2</span> Inline markup end-strings must be immediately preceded by non-whitespace.
+<span class="r5"> 3</span> The inline markup end-string must be separated by at least one character from the start-string.
+<span class="r5"> 4</span> Both, inline markup start-string and end-string must not be preceded by an unescaped backslash (except for the 
+end-string of inline literals). See Escaping Mechanism above for details.
+<span class="r5"> 5</span> If an inline markup start-string is immediately preceded by one of the ASCII characters &#x27; &quot; &lt; ( [ { or a similar 
+non-ASCII character , it must not be followed by the corresponding closing character from &#x27; &quot; &gt; ) ] } or a similar 
+non-ASCII character . (For quotes, matching characters can be any of the quotation marks in international usage.)
+<span class="r4">If the configuration setting </span><span class="r3">character-level-inline-markup</span><span class="r4"> is False (default), additional conditions apply to the </span>
+<span class="r4">characters &quot;around&quot; the inline markup:</span>
+<span class="r5"> 1</span> Inline markup start-strings must start a text block or be immediately preceded by  whitespace,  one of the ASCII 
+characters - : / &#x27; &quot; &lt; ( [ {  or a similar non-ASCII punctuation character. 
+<span class="r5"> 2</span> Inline markup end-strings must end a text block or be immediately followed by  whitespace,  one of the ASCII characte
+- . , : ; ! ? \ / &#x27; &quot; ) ] } &gt;  or a similar non-ASCII punctuation character. 
+<span class="r4">The inline markup recognition rules were devised to allow 90% of non-markup uses of &quot;*&quot;, &quot;`&quot;, &quot;_&quot;, and &quot;|&quot; without </span>
+<span class="r4">escaping. For example, none of the following terms are recognized as containing inline markup strings:</span>
+<span class="r5"> • </span>2 * x  a ** b  (* BOM32_* ` `` _ __ | (breaks rule 1)
+<span class="r5"> • </span>|| (breaks rule 3)
+<span class="r5"> • </span>&quot;*&quot; &#x27;|&#x27; (*) [*] {*} &lt;*&gt; â€˜*â€™ â€š*â€˜ â€˜*â€š â€™*â€™ â€š*â€™ â€œ*â€ â€ž*â€œ â€œ*â€ž â€*â€ â€ž*â€ Â»*Â« â€º*â€¹ Â«*
+Â»*Â» â€º*â€º (breaks rule 5)  &lt;rst-document&gt;:2564: (WARNING/2) Inline emphasis start-string without end-string.  
+&lt;rst-document&gt;:2564: (WARNING/2) Inline emphasis start-string without end-string.  &lt;rst-document&gt;:2564: (WARNING/2) 
+Inline emphasis start-string without end-string.
+<span class="r5"> • </span>2*x a**b O(N**2) e**(x*y) f(x)*f(y) a|b file*.* __init__ __init__()  (breaks rule 6)
+<span class="r4">No escaping is required inside the following inline markup examples:</span>
+<span class="r5"> • </span>*2 * x  *a **b *.txt* (breaks rule 2; renders as &quot;2 * x  *a **b *.txt&quot;)
+<span class="r5"> • </span>*2*x a**b O(N**2) e**(x*y) f(x)*f(y) a*(1+2)* (breaks rule 7; renders as &quot;2*x a**b O(N**2) e**(x*y) f(x)*f(y) a*(1+2)
+<span class="r4">It may be desirable to use </span><span class="r3">inline literals</span><span class="r4"> for some of these anyhow, especially if they represent code snippets.  It&#x27;s a</span>
+<span class="r4">judgment call.The following terms </span><span class="r25">do</span><span class="r4"> require either literal-quoting or escaping to avoid misinterpretation:</span>
+
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r8">*</span><span class="r10">4</span><span class="r7">, class_, </span><span class="r8">*</span><span class="r7">args, </span><span class="r8">**</span><span class="r7">kwargs, </span><span class="r15">`</span><span class="r7">TeX</span><span class="r8">-</span><span class="r7">quoted</span><span class="r11">&#x27;, *ML, *.txt</span><span class="r9">                                                               </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">In most use cases, </span><span class="r3">inline literals</span><span class="r4"> or </span><span class="r3">literal blocks</span><span class="r4"> are the best choice (by default, this also selects a monospaced </span>
+<span class="r4">font). Alternatively, the inline markup characters can be escaped:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">\</span><span class="r8">*</span><span class="r10">4</span><span class="r7">, class\_, \</span><span class="r8">*</span><span class="r7">args, \</span><span class="r8">**</span><span class="r7">kwargs, \</span><span class="r15">`</span><span class="r7">TeX</span><span class="r8">-</span><span class="r7">quoted</span><span class="r11">&#x27;, \*ML, \*.txt</span><span class="r9">                                                        </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">For languages that don&#x27;t use whitespace between words (e.g. Japanese or Chinese) it is recommended to set </span>
+<a class="r3" href="../../user/config.html#character-level-inline-markup">character-level-inline-markup</a><span class="r4"> to True and eventually escape inline markup characters. The examples breaking rules 6 and </span>
+<span class="r4">7 above show which constructs may need special attention.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                  Recognition order                                                   ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Inline markup delimiter characters are used for multiple constructs, so to avoid ambiguity there must be a specific </span>
+<span class="r4">recognition order for each character.  The inline markup recognition order is as follows:</span>
+
+<span class="r5"> • </span>Asterisks: Strong emphasis (&quot;**&quot;) is recognized before emphasis (&quot;*&quot;).
+<span class="r5"> • </span>Backquotes: Inline literals (&quot;``&quot;), inline internal targets (leading &quot;_`&quot;, trailing &quot;`&quot;), are mutually independent, a
+are recognized before phrase hyperlink references (leading &quot;`&quot;, trailing &quot;`_&quot;) and interpreted text (&quot;`&quot;).
+<span class="r5"> • </span>Trailing underscores: Footnote references (&quot;[&quot; + label + &quot;]_&quot;) and simple hyperlink references (name + trailing &quot;_&quot;) 
+mutually independent.
+<span class="r5"> • </span>Vertical bars: Substitution references (&quot;|&quot;) are independently recognized.
+<span class="r5"> • </span>Standalone hyperlinks are the last to be recognized.
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                            Character-Level Inline Markup                                             ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">It is possible to mark up individual characters within a word with backslash escapes (see </span><span class="r3">Escaping Mechanism</span><span class="r4"> above).  </span>
+<span class="r4">Backslash escapes can be used to allow arbitrary text to immediately follow inline markup:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">Python </span><span class="r15">``</span><span class="r7">list</span><span class="r15">``</span><span class="r7">\s use square bracket syntax</span><span class="r8">.</span><span class="r9">                                                                        </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">The backslash will disappear from the processed document.  The word &quot;list&quot; will appear as inline literal text, and the </span>
+<span class="r4">letter &quot;s&quot; will immediately follow it as normal text, with no space in-between.</span>
+
+<span class="r4">Arbitrary text may immediately precede inline markup using backslash-escaped whitespace:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">Possible </span><span class="r8">in</span><span class="r7"> </span><span class="r8">*</span><span class="r7">re</span><span class="r8">*</span><span class="r7">\ </span><span class="r15">``</span><span class="r7">Structured</span><span class="r15">``</span><span class="r7">\ </span><span class="r8">*</span><span class="r7">Text</span><span class="r8">*</span><span class="r7">, though </span><span class="r8">not</span><span class="r7"> encouraged</span><span class="r8">.</span><span class="r9">                                                    </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">The backslashes and spaces separating &quot;re&quot;, &quot;Structured&quot;, and &quot;Text&quot; above will disappear from the processed document.</span>
+
+<span class="r26">╭───────────────────────────────────────────────────── Caution:  ──────────────────────────────────────────────────────╮</span>
+<span class="r26">│ The use of backslash-escapes for character-level inline markup is not encouraged.  Such use is ugly and detrimental  │</span>
+<span class="r26">│ to the unprocessed document&#x27;s readability.  Please use this feature sparingly and only where absolutely necessary.   │</span>
+<span class="r26">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                       Emphasis                                                       ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree element: </span><span class="r3">emphasis</span><span class="r4">.</span>
+
+<span class="r4">Start-string = end-string = &quot;*&quot;.</span>
+
+<span class="r4">Text enclosed by single asterisk characters is emphasized:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">This </span><span class="r8">is</span><span class="r7"> </span><span class="r8">*</span><span class="r7">emphasized text</span><span class="r8">*.</span><span class="r9">                                                                                          </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Emphasized text is typically displayed in italics.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                   Strong Emphasis                                                    ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree element: </span><a class="r3" href="../doctree.html#strong">strong</a><span class="r4">.</span>
+
+<span class="r4">Start-string = end-string = &quot;**&quot;.</span>
+
+<span class="r4">Text enclosed by double-asterisks is emphasized strongly:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">This </span><span class="r8">is</span><span class="r7"> </span><span class="r8">**</span><span class="r7">strong text</span><span class="r8">**.</span><span class="r9">                                                                                            </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Strongly emphasized text is typically displayed in boldface.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                   Interpreted Text                                                   ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree element: depends on the explicit or implicit role and processing.</span>
+
+<span class="r4">Start-string = end-string = &quot;`&quot;.</span>
+
+<span class="r4">Interpreted text is text that is meant to be related, indexed, linked, summarized, or otherwise processed, but the text </span>
+<span class="r4">itself is typically left alone.  Interpreted text is enclosed by single backquote characters:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">This </span><span class="r8">is</span><span class="r7"> </span><span class="r15">`</span><span class="r7">interpreted text</span><span class="r15">`</span><span class="r8">.</span><span class="r9">                                                                                         </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">The &quot;role&quot; of the interpreted text determines how the text is interpreted.  The role may be inferred implicitly (as </span>
+<span class="r4">above; the &quot;default role&quot; is used) or indicated explicitly, using a role marker. A role marker consists of a colon, the </span>
+<span class="r4">role name, and another colon. A role name is a single word consisting of alphanumerics plus isolated internal hyphens, </span>
+<span class="r4">underscores, plus signs, colons, and periods; no whitespace or other characters are allowed.  A role marker is either a </span>
+<span class="r4">prefix or a suffix to the interpreted text, whichever reads better; it&#x27;s up to the author:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">:role:</span><span class="r15">`</span><span class="r7">interpreted text</span><span class="r15">`</span><span class="r9">                                                                                            </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r15">`</span><span class="r7">interpreted text</span><span class="r15">`</span><span class="r7">:role:</span><span class="r9">                                                                                            </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Interpreted text allows extensions to the available inline descriptive markup constructs.  To </span><span class="r3">emphasis</span><span class="r4">, </span><span class="r3">strong emphasis</span><span class="r4">,</span>
+<span class="r3">inline literals</span><span class="r4">, and </span><span class="r3">hyperlink references</span><span class="r4">, we can add &quot;title reference&quot;, &quot;index entry&quot;, &quot;acronym&quot;, &quot;class&quot;, &quot;red&quot;, </span>
+<span class="r4">&quot;blinking&quot; or anything else we want (as long as it is a simple </span><span class="r3">reference name</span><span class="r4">). Only pre-determined roles are </span>
+<span class="r4">recognized; unknown roles will generate errors.  A core set of standard roles is implemented in the reference parser; </span>
+<span class="r4">see </span><a class="r3" href="roles.html">reStructuredText Interpreted Text Roles</a><span class="r4"> for individual descriptions.  The </span><a class="r3" href="directives.html#custom-interpreted-text-roles">role</a><span class="r4"> directive can be used to define </span>
+<span class="r4">custom interpreted text roles.  In addition, applications may support specialized roles.</span>
+
+<span class="r4">In </span><span class="r3">field lists</span><span class="r4">, care must be taken when using interpreted text with explicit roles in field names: the role must be a </span>
+<span class="r4">suffix to the interpreted text. The following are recognized as field list items:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">:</span><span class="r15">`</span><span class="r7">field name</span><span class="r15">`</span><span class="r7">:code:: interpreted text </span><span class="r12">with</span><span class="r7"> explicit role </span><span class="r12">as</span><span class="r7"> suffix</span><span class="r9">                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">:a </span><span class="r15">`</span><span class="r7">complex</span><span class="r15">`</span><span class="r7">:code:\  field name: a backslash</span><span class="r8">-</span><span class="r7">escaped space</span><span class="r9">                                                          </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">                                 </span><span class="r8">is</span><span class="r7"> necessary</span><span class="r9">                                                                       </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">The following are </span><span class="r20">not</span><span class="r4"> recognized as field list items:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">::code:</span><span class="r15">`</span><span class="r8">not</span><span class="r7"> a field name</span><span class="r15">`</span><span class="r7">: paragraph </span><span class="r12">with</span><span class="r7"> interpreted text</span><span class="r9">                                                          </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">:code:</span><span class="r15">`</span><span class="r8">not</span><span class="r7"> a field name</span><span class="r15">`</span><span class="r7">: paragraph </span><span class="r12">with</span><span class="r7"> interpreted text</span><span class="r9">                                                           </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Edge cases:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">:field\:</span><span class="r15">`</span><span class="r7">name</span><span class="r15">`</span><span class="r7">: interpreted text (standard role) requires</span><span class="r9">                                                           </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">                escaping the leading colon </span><span class="r8">in</span><span class="r7"> a field name</span><span class="r9">                                                          </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">:field:\</span><span class="r15">`</span><span class="r7">name</span><span class="r15">`</span><span class="r7">: </span><span class="r8">not</span><span class="r7"> interpreted text</span><span class="r9">                                                                                </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                   Inline Literals                                                    ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree element: </span><a class="r3" href="../doctree.html#literal">literal</a><span class="r4">.</span>
+
+<span class="r4">Start-string = end-string = &quot;``&quot;.</span>
+
+<span class="r4">Text enclosed by double-backquotes is treated as inline literals:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">This text </span><span class="r8">is</span><span class="r7"> an example of </span><span class="r15">``</span><span class="r7">inline literals</span><span class="r15">``</span><span class="r8">.</span><span class="r9">                                                                     </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Inline literals may contain any characters except two adjacent backquotes in an end-string context (according to the </span>
+<span class="r4">recognition rules above).  No markup interpretation (including backslash-escape interpretation) is done within inline </span>
+<span class="r4">literals.</span>
+
+<span class="r4">Line breaks and sequences of whitespace characters are </span><span class="r13">not</span><span class="r4"> protected in inline literals. Although a reStructuredText </span>
+<span class="r4">parser will preserve them in its output, the final representation of the processed document depends on the output </span>
+<span class="r4">formatter, thus the preservation of whitespace cannot be guaranteed.  If the preservation of line breaks and/or other </span>
+<span class="r4">whitespace is important, </span><span class="r3">literal blocks</span><span class="r4"> should be used.</span>
+
+<span class="r4">Inline literals are useful for short code snippets.  For example:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">The regular expression </span><span class="r15">``</span><span class="r7">[</span><span class="r8">+-</span><span class="r7">]</span><span class="r15">?</span><span class="r7">(\d</span><span class="r8">+</span><span class="r7">(\</span><span class="r8">.</span><span class="r7">\d</span><span class="r8">*</span><span class="r7">)</span><span class="r15">?</span><span class="r8">|</span><span class="r7">\</span><span class="r8">.</span><span class="r7">\d</span><span class="r8">+</span><span class="r7">)</span><span class="r15">``</span><span class="r7"> matches</span><span class="r9">                                                         </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">floating</span><span class="r8">-</span><span class="r7">point numbers (without exponents)</span><span class="r8">.</span><span class="r9">                                                                         </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                 Hyperlink References                                                 ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree element: </span><span class="r3">reference</span><span class="r4">.</span>
+
+  <span class="r5"> ∘ </span>Named hyperlink references:
+  <span class="r5"> ∘ </span>No start-string, end-string = &quot;_&quot;.  Start-string = &quot;`&quot;, end-string = &quot;`_&quot;.  (Phrase references.)
+    <span class="r5"> ▪ </span>No start-string, end-string = &quot;_&quot;.
+    <span class="r5"> ▪ </span>Start-string = &quot;`&quot;, end-string = &quot;`_&quot;.  (Phrase references.)
+<span class="r5"> • </span>Start-string = &quot;`&quot;, end-string = &quot;`_&quot;.  (Phrase references.)
+  <span class="r5"> ∘ </span>Anonymous hyperlink references:
+  <span class="r5"> ∘ </span>No start-string, end-string = &quot;__&quot;.  Start-string = &quot;`&quot;, end-string = &quot;`__&quot;.  (Phrase references.)
+    <span class="r5"> ▪ </span>No start-string, end-string = &quot;__&quot;.
+    <span class="r5"> ▪ </span>Start-string = &quot;`&quot;, end-string = &quot;`__&quot;.  (Phrase references.)
+<span class="r5"> • </span>Start-string = &quot;`&quot;, end-string = &quot;`__&quot;.  (Phrase references.)
+<span class="r4">Hyperlink references are indicated by a trailing underscore, &quot;_&quot;, except for </span><span class="r3">standalone hyperlinks</span><span class="r4"> which are recognized </span>
+<span class="r4">independently.  The underscore can be thought of as a right-pointing arrow.  The trailing underscores point away from </span>
+<span class="r4">hyperlink references, and the leading underscores point toward </span><span class="r3">hyperlink targets</span><span class="r4">.Hyperlinks consist of two parts.  In </span>
+<span class="r4">the text body, there is a source link, a reference name with a trailing underscore (or two underscores for </span><span class="r3">anonymous </span>
+<span class="r3">hyperlinks</span><span class="r4">):</span>
+
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">See the Python_ home page </span><span class="r12">for</span><span class="r7"> info</span><span class="r8">.</span><span class="r9">                                                                                 </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">A target link with a matching reference name must exist somewhere else in the document.  See </span><span class="r3">Hyperlink Targets</span><span class="r4"> for a </span>
+<span class="r4">full description).</span>
+
+<span class="r3">Anonymous hyperlinks</span><span class="r4"> (which see) do not use reference names to match references to targets, but otherwise behave </span>
+<span class="r4">similarly to named hyperlinks.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                              Embedded URIs and Aliases                                               ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">A hyperlink reference may directly embed a target URI or (since DocutilsÂ 0.11) a hyperlink reference within angle </span>
+<span class="r4">brackets (&quot;&lt;...&gt;&quot;) as follows:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">See the </span><span class="r15">`</span><span class="r7">Python home page </span><span class="r8">&lt;</span><span class="r7">https:</span><span class="r8">//</span><span class="r7">www</span><span class="r8">.</span><span class="r7">python</span><span class="r8">.</span><span class="r7">org</span><span class="r8">&gt;</span><span class="r15">`</span><span class="r7">_ </span><span class="r12">for</span><span class="r7"> info</span><span class="r8">.</span><span class="r9">                                                      </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">This </span><span class="r15">`</span><span class="r7">link </span><span class="r8">&lt;</span><span class="r7">Python home page_</span><span class="r8">&gt;</span><span class="r15">`</span><span class="r7">_ </span><span class="r8">is</span><span class="r7"> an alias to the link above</span><span class="r8">.</span><span class="r9">                                                     </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">This is exactly equivalent to:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">See the </span><span class="r15">`</span><span class="r7">Python home page</span><span class="r15">`</span><span class="r7">_ </span><span class="r12">for</span><span class="r7"> info</span><span class="r8">.</span><span class="r9">                                                                               </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">This link_ </span><span class="r8">is</span><span class="r7"> an alias to the link above</span><span class="r8">.</span><span class="r9">                                                                           </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> _Python home page: https:</span><span class="r8">//</span><span class="r7">www</span><span class="r8">.</span><span class="r7">python</span><span class="r8">.</span><span class="r7">org</span><span class="r9">                                                                        </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> _link: </span><span class="r15">`</span><span class="r7">Python home page</span><span class="r15">`</span><span class="r7">_</span><span class="r9">                                                                                       </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">The bracketed URI must be preceded by whitespace and be the last text before the end string.</span>
+
+<span class="r4">With a single trailing underscore, the reference is named and the same target URI may be referred to again. With two </span>
+<span class="r4">trailing underscores, the reference and target are both anonymous, and the target cannot be referred to again.  These </span>
+<span class="r4">are &quot;one-off&quot; hyperlinks.  For example:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r15">`</span><span class="r7">RFC </span><span class="r10">2396</span><span class="r7"> </span><span class="r8">&lt;</span><span class="r7">https:</span><span class="r8">//</span><span class="r7">www</span><span class="r8">.</span><span class="r7">rfc</span><span class="r8">-</span><span class="r7">editor</span><span class="r8">.</span><span class="r7">org</span><span class="r8">/</span><span class="r7">rfc</span><span class="r8">/</span><span class="r7">rfc2396</span><span class="r8">.</span><span class="r7">txt</span><span class="r8">&gt;</span><span class="r15">`</span><span class="r7">__ </span><span class="r8">and</span><span class="r7"> </span><span class="r15">`</span><span class="r7">RFC</span><span class="r9">                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r10">2732</span><span class="r7"> </span><span class="r8">&lt;</span><span class="r7">https:</span><span class="r8">//</span><span class="r7">www</span><span class="r8">.</span><span class="r7">rfc</span><span class="r8">-</span><span class="r7">editor</span><span class="r8">.</span><span class="r7">org</span><span class="r8">/</span><span class="r7">rfc</span><span class="r8">/</span><span class="r7">rfc2732</span><span class="r8">.</span><span class="r7">txt</span><span class="r8">&gt;</span><span class="r15">`</span><span class="r7">__ together</span><span class="r9">                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">define the syntax of URIs</span><span class="r8">.</span><span class="r9">                                                                                          </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Equivalent to:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r15">`</span><span class="r7">RFC </span><span class="r10">2396</span><span class="r15">`</span><span class="r7">__ </span><span class="r8">and</span><span class="r7"> </span><span class="r15">`</span><span class="r7">RFC </span><span class="r10">2732</span><span class="r15">`</span><span class="r7">__ together define the syntax of URIs</span><span class="r8">.</span><span class="r9">                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">__ https:</span><span class="r8">//</span><span class="r7">www</span><span class="r8">.</span><span class="r7">rfc</span><span class="r8">-</span><span class="r7">editor</span><span class="r8">.</span><span class="r7">org</span><span class="r8">/</span><span class="r7">rfc</span><span class="r8">/</span><span class="r7">rfc2396</span><span class="r8">.</span><span class="r7">txt</span><span class="r9">                                                                       </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">__ https:</span><span class="r8">//</span><span class="r7">www</span><span class="r8">.</span><span class="r7">rfc</span><span class="r8">-</span><span class="r7">editor</span><span class="r8">.</span><span class="r7">org</span><span class="r8">/</span><span class="r7">rfc</span><span class="r8">/</span><span class="r7">rfc2732</span><span class="r8">.</span><span class="r7">txt</span><span class="r9">                                                                       </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r3">Standalone hyperlinks</span><span class="r4"> are treated as URIs, even if they end with an underscore like in the example of a Python function </span>
+<span class="r4">documentation:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r15">`</span><span class="r21">__init__</span><span class="r7"> </span><span class="r8">&lt;</span><span class="r7">http:example</span><span class="r8">.</span><span class="r7">py</span><span class="r8">.</span><span class="r7">html</span><span class="r22">#__init__&gt;`__</span><span class="r9">                                                                        </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">If a target URI that is not recognized as </span><span class="r3">standalone hyperlink</span><span class="r4"> happens to end with an underscore, this needs to be </span>
+<span class="r4">backslash-escaped to avoid being parsed as hyperlink reference. For example</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">Use the </span><span class="r15">`</span><span class="r7">source </span><span class="r8">&lt;</span><span class="r7">parrots</span><span class="r8">.</span><span class="r7">txt\_</span><span class="r8">&gt;</span><span class="r15">`</span><span class="r7">__</span><span class="r8">.</span><span class="r9">                                                                                 </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">creates an anonymous reference to the file </span><span class="r14">parrots.txt_</span><span class="r4">.</span>
+
+<span class="r4">If the reference text happens to end with angle-bracketed text that is </span><span class="r13">not</span><span class="r4"> a URI or hyperlink reference, at least one </span>
+<span class="r4">angle-bracket needs to be backslash-escaped or an escaped space should follow. For example, here are three references to</span>
+<span class="r4">titles describing a tag:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">See </span><span class="r15">`</span><span class="r7">HTML Element: \</span><span class="r8">&lt;</span><span class="r7">a</span><span class="r8">&gt;</span><span class="r15">`</span><span class="r7">_, </span><span class="r15">`</span><span class="r7">HTML Element: </span><span class="r8">&lt;</span><span class="r7">b\</span><span class="r8">&gt;</span><span class="r7"> </span><span class="r15">`</span><span class="r7">_, </span><span class="r8">and</span><span class="r9">                                                              </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r15">`</span><span class="r7">HTML Element: </span><span class="r8">&lt;</span><span class="r7">c</span><span class="r8">&gt;</span><span class="r7">\ </span><span class="r15">`</span><span class="r7">_</span><span class="r8">.</span><span class="r9">                                                                                             </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">The reference text may also be omitted, in which case the URI will be duplicated for use as the reference text.  This is</span>
+<span class="r4">useful for relative URIs where the address or file name is also the desired reference text:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">See </span><span class="r15">`</span><span class="r8">&lt;</span><span class="r7">a_named_relative_link</span><span class="r8">&gt;</span><span class="r15">`</span><span class="r7">_ </span><span class="r8">or</span><span class="r7"> </span><span class="r15">`</span><span class="r8">&lt;</span><span class="r7">an_anonymous_relative_link</span><span class="r8">&gt;</span><span class="r15">`</span><span class="r7">__</span><span class="r9">                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r12">for</span><span class="r7"> details</span><span class="r8">.</span><span class="r9">                                                                                                        </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r26">╭───────────────────────────────────────────────────── Caution:  ──────────────────────────────────────────────────────╮</span>
+<span class="r26">│ This construct offers easy authoring and maintenance of hyperlinks at the expense of general readability.  Inline    │</span>
+<span class="r26">│ URIs, especially long ones, inevitably interrupt the natural flow of text.  For documents meant to be read in source │</span>
+<span class="r26">│ form, the use of independent block-level hyperlink targets is strongly recommended.  The embedded URI construct is   │</span>
+<span class="r26">│ most suited to documents intended only to be read in processed form.                                                 │</span>
+<span class="r26">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                               Inline Internal Targets                                                ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree element: </span><a class="r3" href="../doctree.html#target">target</a><span class="r4">.</span>
+
+<span class="r4">Start-string = &quot;_`&quot;, end-string = &quot;`&quot;.</span>
+
+<span class="r4">Inline internal targets are the equivalent of explicit </span><span class="r3">internal hyperlink targets</span><span class="r4">, but may appear within running text.  </span>
+<span class="r4">The syntax begins with an underscore and a backquote, is followed by a hyperlink name or phrase, and ends with a </span>
+<span class="r4">backquote.  Inline internal targets may not be anonymous.</span>
+
+<span class="r4">For example, the following paragraph contains a hyperlink target named &quot;Norwegian Blue&quot;:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">Oh yes, the _</span><span class="r15">`</span><span class="r7">Norwegian Blue</span><span class="r15">`</span><span class="r8">.</span><span class="r7">  What</span><span class="r11">&#x27;s, um, what&#x27;</span><span class="r7">s wrong </span><span class="r12">with</span><span class="r7"> it</span><span class="r15">?</span><span class="r9">                                                   </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">See </span><span class="r3">Implicit Hyperlink Targets</span><span class="r4"> for the resolution of duplicate reference names.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                 Footnote References                                                  ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">See also: </span><span class="r3">Footnotes</span>
+
+<span class="r4">Doctree element: </span><a class="r3" href="../doctree.html#footnote-reference">footnote_reference</a><span class="r4">.</span>
+
+<span class="r4">Configuration settings: </span><span class="r3">footnote_references</span><span class="r4">, </span><a class="r3" href="../../user/config.html#trim-footnote-reference-space">trim_footnote_reference_space</a><span class="r4">.</span>
+
+<span class="r4">Start-string = &quot;[&quot;, end-string = &quot;]_&quot;.</span>
+
+<span class="r4">Each footnote reference consists of a square-bracketed label followed by a trailing underscore.  Footnote labels are one</span>
+<span class="r4">of:</span>
+
+<span class="r5"> • </span>one or more digits (i.e., a number),
+<span class="r5"> • </span>a single &quot;#&quot; (denoting auto-numbered footnotes),
+<span class="r5"> • </span>a &quot;#&quot; followed by a simple reference name (an autonumber label), or
+<span class="r5"> • </span>a single &quot;*&quot; (denoting auto-symbol footnotes).
+<span class="r4">For example:</span>
+
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">Please RTFM [</span><span class="r10">1</span><span class="r7">]_</span><span class="r8">.</span><span class="r9">                                                                                                   </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r8">..</span><span class="r7"> [</span><span class="r10">1</span><span class="r7">] Read The Fine Manual</span><span class="r9">                                                                                         </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r3">Inline markup recognition rules</span><span class="r4"> may require whitespace in front of the footnote reference. To remove the whitespace from</span>
+<span class="r4">the output, use an escaped whitespace character (see </span><span class="r3">Escaping Mechanism</span><span class="r4">) or set the </span><span class="r3">trim_footnote_reference_space</span><span class="r4"> </span>
+<span class="r4">configuration setting. Leading whitespace is removed by default, if the </span><span class="r3">footnote_references setting</span><span class="r4"> is &quot;superscript&quot;.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                 Citation References                                                  ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">See also: </span><span class="r3">Citations</span>
+
+<span class="r4">Doctree element: </span><a class="r3" href="../doctree.html#citation-reference">citation_reference</a><span class="r4">.</span>
+
+<span class="r4">Start-string = &quot;[&quot;, end-string = &quot;]_&quot;.</span>
+
+<span class="r4">Each citation reference consists of a square-bracketed label followed by a trailing underscore.  Citation labels are </span>
+<span class="r4">simple </span><span class="r3">reference names</span><span class="r4"> (case-insensitive single words, consisting of alphanumerics plus internal hyphens, underscores, </span>
+<span class="r4">and periods; no whitespace).</span>
+
+<span class="r4">For example:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">Here </span><span class="r8">is</span><span class="r7"> a citation reference: [CIT2002]_</span><span class="r8">.</span><span class="r9">                                                                           </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                               Substitution References                                                ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree elements: </span><a class="r3" href="../doctree.html#substitution-reference">substitution_reference</a><span class="r4">, </span><span class="r3">reference</span><span class="r4">.</span>
+
+<span class="r4">Start-string = &quot;|&quot;, end-string = &quot;|&quot; (optionally followed by &quot;_&quot; or &quot;__&quot;).</span>
+
+<span class="r4">Vertical bars are used to bracket the substitution reference text.  A substitution reference may also be a hyperlink </span>
+<span class="r4">reference by appending a &quot;_&quot; (named) or &quot;__&quot; (anonymous) suffix; the substitution text is used for the reference text in</span>
+<span class="r4">the named case.</span>
+
+<span class="r4">The processing system replaces substitution references with the processed contents of the corresponding </span><span class="r3">substitution </span>
+<span class="r3">definitions</span><span class="r4"> (which see for the definition of &quot;correspond&quot;).  Substitution definitions produce inline-compatible </span>
+<span class="r4">elements.</span>
+
+<span class="r4">Examples:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">This </span><span class="r8">is</span><span class="r7"> a simple </span><span class="r8">|</span><span class="r7">substitution reference</span><span class="r8">|.</span><span class="r7">  It will be replaced by</span><span class="r9">                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">the processing system</span><span class="r8">.</span><span class="r9">                                                                                              </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r9">                                                                                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">This </span><span class="r8">is</span><span class="r7"> a combination </span><span class="r8">|</span><span class="r7">substitution </span><span class="r8">and</span><span class="r7"> hyperlink reference</span><span class="r8">|</span><span class="r7">_</span><span class="r8">.</span><span class="r7">  In</span><span class="r9">                                                  </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">addition to being replaced, the replacement text </span><span class="r8">or</span><span class="r7"> element will</span><span class="r9">                                                    </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">refer to the </span><span class="r11">&quot;substitution and hyperlink reference&quot;</span><span class="r7"> target</span><span class="r8">.</span><span class="r9">                                                         </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                Standalone Hyperlinks                                                 ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree element: </span><a class="r3" href="../doctree.html#reference">reference</a><span class="r4">.</span>
+
+<span class="r4">No start-string or end-string.</span>
+
+<span class="r4">A URI (absolute URI  or standalone email address) within a text block is treated as a general external hyperlink with </span>
+<span class="r4">the URI itself as the link&#x27;s text.  For example:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">See https:</span><span class="r8">//</span><span class="r7">www</span><span class="r8">.</span><span class="r7">python</span><span class="r8">.</span><span class="r7">org </span><span class="r12">for</span><span class="r7"> info</span><span class="r8">.</span><span class="r9">                                                                                </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">would be marked up in HTML as:</span>
+<span class="r6">┌─────────────────────────────────────────────────────── python ───────────────────────────────────────────────────────┐</span>
+<span class="r6">│</span> <span class="r7">See </span><span class="r8">&lt;</span><span class="r7">a href</span><span class="r8">=</span><span class="r11">&quot;https://www.python.org&quot;</span><span class="r8">&gt;</span><span class="r7">https:</span><span class="r8">//</span><span class="r7">www</span><span class="r8">.</span><span class="r7">python</span><span class="r8">.</span><span class="r7">org</span><span class="r8">&lt;/</span><span class="r7">a</span><span class="r8">&gt;</span><span class="r7"> </span><span class="r12">for</span><span class="r9">                                                 </span> <span class="r6">│</span>
+<span class="r6">│</span> <span class="r7">info</span><span class="r8">.</span><span class="r9">                                                                                                               </span> <span class="r6">│</span>
+<span class="r6">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="r4">Two forms of URI are recognized:</span>
+
+<span class="r5"> 1</span> Absolute URIs.  These consist of a scheme, a colon (&quot;:&quot;), and a scheme-specific part whose interpretation depends on 
+scheme.  The scheme is the name of the protocol, such as &quot;http&quot;, &quot;ftp&quot;, &quot;mailto&quot;, or &quot;telnet&quot;.  The scheme consists of 
+an initial letter, followed by letters, numbers, and/or &quot;+&quot;, &quot;-&quot;, &quot;.&quot;.  Recognition is limited to known schemes, per the
+Official IANA Registry of URI Schemes and the W3C&#x27;s Retired Index of WWW Addressing Schemes.  The scheme-specific part 
+of the resource identifier may be either hierarchical or opaque:  Hierarchical identifiers begin with one or two slashes
+and may use slashes to separate hierarchical components of the path. Examples are web pages and FTP sites:  
+https://www.python.org  ftp://ftp.python.org/pub/python  Opaque identifiers do not begin with slashes.  Examples are 
+email addresses and newsgroups:  mailto:someone@somewhere.com  news:comp.lang.python  With queries, fragments, and 
+%-escape sequences, URIs can become quite complicated.  A reStructuredText parser must be able to recognize any absolute
+URI, as defined in RFC2396 and RFC2732.
+<span class="r5"> 2</span> Standalone email addresses, which are treated as if they were absolute URIs with a &quot;mailto:&quot; scheme.  Example:  
+someone@somewhere.com
+<span class="r4">Punctuation at the end of a URI is not considered part of the URI, unless the URI is terminated by a closing angle </span>
+<span class="r4">bracket (&quot;&gt;&quot;). Backslashes may be used in URIs to escape markup characters, specifically asterisks (&quot;*&quot;) and underscores</span>
+<span class="r4">(&quot;_&quot;) which are valid URI characters (see </span><span class="r3">Escaping Mechanism</span><span class="r4"> above).</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                        Units                                                         ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">(New in Docutils 0.3.10.)</span>
+
+<span class="r4">All measures consist of a positive floating point number in standard (non-scientific) notation and a unit, possibly </span>
+<span class="r4">separated by one or more spaces.</span>
+
+<span class="r4">Units are only supported where explicitly mentioned in the reference manuals.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                     Length Units                                                     ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">The following length units are supported by the reStructuredText parser:</span>
+
+<span class="r5"> • </span>em (em unit, the element&#x27;s font size)
+<span class="r5"> • </span>ex (ex unit, x-height of the elementâ€™s font)
+<span class="r5"> • </span>mm (millimeters; 1Â mm = 1/1000Â m)
+<span class="r5"> • </span>cm (centimeters; 1Â cm = 10Â mm)
+<span class="r5"> • </span>in (inches; 1Â in = 2.54Â cm = 96Â px)
+<span class="r5"> • </span>px (pixels, 1Â px = 1/96Â in) 
+<span class="r5"> • </span>pt (points; 1Â pt = 1/72Â in)
+<span class="r5"> • </span>pc (picas; 1Â pc = 1/6Â in = 12Â pt)
+<span class="r4">This set corresponds to the </span><a class="r3" href="https://www.w3.org/TR/CSS2/syndata.html#length-units">length units in CSS2</a><span class="r4"> (a subset of </span><a class="r3" href="https://www.w3.org/TR/css-values-3/#absolute-lengths">length units in CSS3</a><span class="r4">).The following are all valid length </span>
+<span class="r4">values: &quot;1.5em&quot;, &quot;20 mm&quot;, &quot;.5in&quot;.Length values without unit are completed with a writer-dependent default (e.g. &quot;px&quot; </span>
+<span class="r4">with HTML, &quot;pt&quot; with latex2e). See the writer specific documentation in the </span><span class="r3">user doc</span><span class="r4"> for details.</span>
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                   Percentage Units                                                   ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Percentage values have a percent sign (&quot;%&quot;) as unit.  Percentage values are relative to other values, depending on the </span>
+<span class="r4">context in which they occur.</span>
+
+<span class="r1">╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗</span>
+<span class="r1">║                                                    Error Handling                                                    ║</span>
+<span class="r1">╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝</span>
+<span class="r4">Doctree elements: </span><a class="r3" href="../doctree.html#system-message">system_message</a><span class="r4">, </span><a class="r3" href="../doctree.html#problematic">problematic</a><span class="r4">.</span>
+
+<span class="r4">Markup errors are handled according to the specification in </span><a class="r3" href="../../peps/pep-0258.html">PEP 258</a><span class="r4">.</span>
+
+<span class="r27">╭────────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 5); ──────────────────────────────────╮</span>
+<span class="r27">│</span> <span class="r1">&lt;</span><span class="r28">rst-document</span><span class="r1">&gt;</span>:<span class="r27">5</span>: <span class="r1">(</span>INFO/<span class="r27">1</span><span class="r1">)</span> Enumerated list start value not ordinal-<span class="r27">1</span>: <span class="r29">&quot;6&quot;</span> <span class="r1">(</span>ordinal <span class="r27">6</span><span class="r1">)</span>                                <span class="r27">│</span>
+<span class="r27">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r27">╭──────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 3197); ─────────────────────────────────╮</span>
+<span class="r27">│</span> <span class="r1">&lt;</span><span class="r28">rst-document</span><span class="r1">&gt;</span>:<span class="r27">3197</span>: <span class="r1">(</span>INFO/<span class="r27">1</span><span class="r1">)</span> Duplicate explicit target name: <span class="r29">&quot;topic&quot;</span>.                                               <span class="r27">│</span>
+<span class="r27">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r27">╭──────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 3208); ─────────────────────────────────╮</span>
+<span class="r27">│</span> <span class="r1">&lt;</span><span class="r28">rst-document</span><span class="r1">&gt;</span>:<span class="r27">3208</span>: <span class="r1">(</span>INFO/<span class="r27">1</span><span class="r1">)</span> Duplicate explicit target name: <span class="r29">&quot;list_item&quot;</span>.                                           <span class="r27">│</span>
+<span class="r27">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r27">╭──────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 3254); ─────────────────────────────────╮</span>
+<span class="r27">│</span> <span class="r1">&lt;</span><span class="r28">rst-document</span><span class="r1">&gt;</span>:<span class="r27">3254</span>: <span class="r1">(</span>INFO/<span class="r27">1</span><span class="r1">)</span> Duplicate explicit target name: <span class="r29">&quot;reference&quot;</span>.                                           <span class="r27">│</span>
+<span class="r27">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r27">╭──────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 3255); ─────────────────────────────────╮</span>
+<span class="r27">│</span> <span class="r1">&lt;</span><span class="r28">rst-document</span><span class="r1">&gt;</span>:<span class="r27">3255</span>: <span class="r1">(</span>INFO/<span class="r27">1</span><span class="r1">)</span> Duplicate explicit target name: <span class="r29">&quot;reference&quot;</span>.                                           <span class="r27">│</span>
+<span class="r27">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+<span class="r30">┌─────────────────────────────────────────────────────── Footer ───────────────────────────────────────────────────────┐</span>
+<span class="r30">│</span>                          In LaTeX, the default definition is 1Â px = 1/72Â in (cf. How to                            <span class="r30">│</span>
+<span class="r30">│</span>                          configure the size of a pixel in the LaTeX writer documentation).                           <span class="r30">│</span>
+<span class="r30">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+</code></pre>
+</body>
+</html>

--- a/tests/test_vectors/specification_expected.html
+++ b/tests/test_vectors/specification_expected.html
@@ -2110,7 +2110,6 @@ someone@somewhere.com
 <span class="r4">Doctree elements: </span><a class="r3" href="../doctree.html#system-message">system_message</a><span class="r4">, </span><a class="r3" href="../doctree.html#problematic">problematic</a><span class="r4">.</span>
 
 <span class="r4">Markup errors are handled according to the specification in </span><a class="r3" href="../../peps/pep-0258.html">PEP 258</a><span class="r4">.</span>
-
 <span class="r27">╭────────────────────────────────── System Message: INFO/1 (&lt;rst-document&gt;, line 5); ──────────────────────────────────╮</span>
 <span class="r27">│</span> <span class="r1">&lt;</span><span class="r28">rst-document</span><span class="r1">&gt;</span>:<span class="r27">5</span>: <span class="r1">(</span>INFO/<span class="r27">1</span><span class="r1">)</span> Enumerated list start value not ordinal-<span class="r27">1</span>: <span class="r29">&quot;6&quot;</span> <span class="r1">(</span>ordinal <span class="r27">6</span><span class="r1">)</span>                                <span class="r27">│</span>
 <span class="r27">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</span>


### PR DESCRIPTION
Very small PR that removes the two extra newlines mentioned in #9. Trailing newlines don't really make sense in the context of rst, and the new behavior is more in line with the native `rich.Markdown`.

I would consider the previous behavior a bug, so no need for any flags or anything.

Based on #11, so merge that first and this PR will become much much smaller 😄 