### PR TITLE
fix: resolve combined cspan+rspan placeholder in _origin

### DIFF
--- a/rich_rst/__init__.py
+++ b/rich_rst/__init__.py
@@ -2810,23 +2810,33 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
                     if cc + csp >= c:
                         return (r, cc)
                     break
-            # Scan up — rspan placeholder
+            # Scan up — rspan placeholder in same column
             for rr in range(r - 1, -1, -1):
                 if grid[rr][c] is not None:
-                    _, csp, rsp = grid[rr][c]
+                    _, _, rsp = grid[rr][c]
                     if rr + rsp >= r:
                         return (rr, c)
                     break
+            # Two-step: combined cspan+rspan placeholder — for each row above,
+            # scan left to find a real cell that covers (r, c) in both dimensions.
+            for rr in range(r - 1, -1, -1):
+                for cc in range(c - 1, -1, -1):
+                    cell = grid[rr][cc]
+                    if cell is not None:
+                        _, csp, rsp = cell
+                        if cc + csp >= c and rr + rsp >= r:
+                            return (rr, cc)
+                        break  # first real cell in this row is definitive
             return None
 
         def _rspan_continues(row_above: int, c: int) -> bool:
             """True if an rspan cell above is still active at the row boundary."""
-            for rr in range(row_above, -1, -1):
-                cell = grid[rr][c]
-                if cell is not None:
-                    _, _, rsp = cell
-                    return rr + rsp > row_above
-            return False
+            orig = _origin(row_above, c)
+            if orig is None:
+                return False
+            or_r, or_c = orig
+            _, _, rsp = grid[or_r][or_c]
+            return or_r + rsp > row_above
 
         def _cspan_continues(r: int, c: int) -> bool:
             """True if column c is a cspan continuation of the cell to its left in row r."""
@@ -2941,7 +2951,7 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
                 else:
                     # rspan placeholder — empty cell
                     s += " " * (col_widths[c] + 2)
-                    if c < ncols - 1 and not _cspan_continues(r, c + 1):
+                    if c < ncols - 1 and _has_vborder(r, c):
                         s += V
                     c += 1
             s += V

--- a/rich_rst/__init__.py
+++ b/rich_rst/__init__.py
@@ -2836,7 +2836,6 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
                 if grid[r][cc] is not None:
                     _, csp, _ = grid[r][cc]
                     return cc + csp >= c
-                break
             return False
 
         def _is_header(r: int) -> bool:

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -505,6 +505,59 @@ def test_flat_table_rspan2_separator_all_rows(render_text):
     )
 
 
+def test_flat_table_combined_cspan_rspan_no_internal_border(render_text):
+    """A single cell with :cspan:`1` :rspan:`1` must create a seamless 2×2 block.
+
+    Grid layout:
+        Row 0 (header): [A,      B,    C   ]
+        Row 1 (data):   [Big(1,1), None, C1 ]
+        Row 2 (data):   [None,   None, C2   ]
+
+    The corner placeholder at (2,1) is a combined cspan+rspan slot that neither
+    a left-scan (row 2 has no real cells) nor an up-scan (col 1 has no real
+    cells above) can resolve.  The two-step diagonal search in _origin must
+    trace it back to (1,0), after which _has_vborder(2,0) returns False and
+    _rspan_continues(1,1) returns True — eliminating the spurious internal
+    border and the incorrect horizontal rule through the merged region.
+    """
+    rst = (
+        ".. flat-table::\n"
+        "   :header-rows: 1\n\n"
+        "   * - A\n"
+        "     - B\n"
+        "     - C\n\n"
+        "   * - :cspan:`1` :rspan:`1` Big\n"
+        "     - C1\n\n"
+        "   * - C2\n"
+    )
+    out = render_text(rst)
+    lines = out.splitlines()
+
+    assert "Big" in out, "Combined-span cell content must appear"
+    assert "C1" in out, "Sibling cell C1 in row 1 must appear"
+    assert "C2" in out, "Cell C2 in the continuation row must appear"
+
+    # The continuation row (C2 row) covers cols 0-1 with the Big rspan and
+    # puts C2 at col 2.  No internal │ between cols 0 and 1 expected.
+    c2_line = next((l for l in lines if "C2" in l and "Big" not in l), None)
+    assert c2_line is not None, "Row containing C2 (continuation row) must be present"
+    assert c2_line.count("│") == 3, (
+        f"Combined 2×2 span: continuation row must have exactly 3 │ borders "
+        f"(outer-left, span-boundary, outer-right), got {c2_line.count('│')} "
+        f"in {c2_line!r}"
+    )
+
+    # The row separator between Big's row and the continuation row must keep
+    # the Big span open: it should start with │ (not ├/└) and have a │ between
+    # the two spanned columns (not a junction or horizontal rule).
+    big_line_idx = next((i for i, l in enumerate(lines) if "Big" in l), None)
+    assert big_line_idx is not None
+    sep = lines[big_line_idx + 1] if big_line_idx + 1 < len(lines) else ""
+    assert sep.startswith("│"), (
+        "Separator after Big row must start with │ — cols 0-1 are still spanned"
+    )
+
+
 def test_flat_table_rspan_body_row_separator(render_text):
     """A body cell with :rspan:`1` continues visually across the row separator.
 

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -423,6 +423,88 @@ def test_flat_table_rspan_header_into_body_column_order(render_text):
     )
 
 
+def test_flat_table_cspan2_partial_no_internal_borders(render_text):
+    """A body cell with :cspan:`2` (3 of 4 cols) must show no internal │ borders.
+
+    This is the critical regression path for the _cspan_continues bug: the
+    scan-left loop must cross the None placeholder at col 1 to reach the origin
+    at col 0 when checking whether col 2 is a continuation.  With the old
+    unconditional ``break`` the scan stopped at the None and returned False,
+    drawing a spurious internal border.
+    """
+    rst = (
+        ".. flat-table::\n"
+        "   :header-rows: 1\n\n"
+        "   * - A\n"
+        "     - B\n"
+        "     - C\n"
+        "     - D\n\n"
+        "   * - :cspan:`2` Merged ABC\n"
+        "     - normal D\n"
+    )
+    out = render_text(rst)
+    lines = out.splitlines()
+    merged_line = next((l for l in lines if "Merged ABC" in l), None)
+    assert merged_line is not None, "Row containing 'Merged ABC' must be present"
+    # Cols 0–2 are merged → no internal │ between them; one border between col 2 and col 3.
+    # Expected: │ Merged ABC   │ normal D │  →  3 vertical bars total.
+    assert merged_line.count("│") == 3, (
+        f"Merged ABC spans 3 cols: expected 3 │ borders (left, mid, right), "
+        f"got {merged_line.count('│')} in {merged_line!r}"
+    )
+
+
+def test_flat_table_rspan2_separator_all_rows(render_text):
+    """A cell with :rspan:`2` (spanning 3 rows) keeps the separator opening on all
+    intermediate rows — verifying _rspan_continues handles multi-row spans correctly.
+
+    This is the 'opposite direction' counterpart to the cspan_continues fix: the
+    rspan scan goes *upward* past None placeholders, and must not break early.
+    """
+    rst = (
+        ".. flat-table::\n"
+        "   :header-rows: 1\n\n"
+        "   * - Category\n"
+        "     - Item\n\n"
+        "   * - :rspan:`2` All three\n"
+        "     - First\n\n"
+        "   * - Second\n\n"
+        "   * - Third\n"
+    )
+    out = render_text(rst)
+    lines = out.splitlines()
+    # All three item rows must be present
+    assert "First" in out
+    assert "Second" in out
+    assert "Third" in out
+    # Each item row: col 0 is the rspan placeholder → starts with │ + spaces
+    for label in ("First", "Second", "Third"):
+        row = next((l for l in lines if label in l), None)
+        assert row is not None, f"Row containing '{label}' must be present"
+        if label != "First":
+            # Rows 2 and 3: col 0 is covered by the rspan → must be empty, not contain label text
+            first_inner_sep = row.index("│", 1)
+            col0_content = row[1:first_inner_sep]
+            assert col0_content.strip() == "", (
+                f"Category column must be empty in the '{label}' row "
+                f"(rspan from 'All three' still active), got {col0_content!r}"
+            )
+    # The separator between First and Second rows must start with │ (rspan continues col 0)
+    first_line_idx = next(i for i, l in enumerate(lines) if "First" in l)
+    sep_line = lines[first_line_idx + 1] if first_line_idx + 1 < len(lines) else ""
+    assert sep_line.startswith("│"), (
+        "Row separator after 'First' row must start with │ — "
+        "col 0 is still spanned by the 3-row rspan"
+    )
+    # The separator between Second and Third rows must also start with │
+    second_line_idx = next(i for i, l in enumerate(lines) if "Second" in l)
+    sep_line2 = lines[second_line_idx + 1] if second_line_idx + 1 < len(lines) else ""
+    assert sep_line2.startswith("│"), (
+        "Row separator after 'Second' row must start with │ — "
+        "col 0 is still spanned by the 3-row rspan on its third row"
+    )
+
+
 def test_flat_table_rspan_body_row_separator(render_text):
     """A body cell with :rspan:`1` continues visually across the row separator.
 

--- a/tools/generate_demo_page.py
+++ b/tools/generate_demo_page.py
@@ -922,6 +922,21 @@ DEMOS = [
                        * - Bottom-right
                          - Also bottom-right"""),
             },
+            {
+                "name": "flat-table — single cell with :cspan: and :rspan: (2×2 block)",
+                "rst": textwrap.dedent("""\
+                    .. flat-table:: 2×2 merged cell
+                       :header-rows: 1
+
+                       * - Task
+                         - Mon
+                         - Tue
+
+                       * - :cspan:`1` :rspan:`1` Planning
+                         - Review
+
+                       * - Deploy"""),
+            },
         ],
     },
     # ── 8. Footnotes and citations ────────────────────────────────────────────

--- a/tools/generate_demo_page.py
+++ b/tools/generate_demo_page.py
@@ -855,6 +855,35 @@ DEMOS = [
                          - 76"""),
             },
             {
+                "name": "flat-table — wide partial column span (:cspan: > 1)",
+                "rst": textwrap.dedent("""\
+                    .. flat-table:: Regional Sales
+                       :header-rows: 1
+
+                       * - Region
+                         - Q1
+                         - Q2
+                         - Q3
+
+                       * - :cspan:`2` North + Central + South combined
+                         - 312
+
+                       * - North
+                         - 42
+                         - 55
+                         - 61
+
+                       * - Central
+                         - 78
+                         - 90
+                         - 83
+
+                       * - South
+                         - 34
+                         - 48
+                         - 55"""),
+            },
+            {
                 "name": "flat-table — row span (:rspan:)",
                 "rst": textwrap.dedent("""\
                     .. flat-table:: Produce Prices


### PR DESCRIPTION
## Summary

- **`_origin` diagonal search**: A cell with both `:cspan:` and `:rspan:` produces a corner `None` placeholder that is unreachable by independent left-scan or up-scan. Added a third fallback that walks upward row by row, then scans left within each row to find the real cell covering `(r, c)` in both dimensions.
- **`_rspan_continues` via `_origin`**: Rewrote to delegate to `_origin` instead of scanning `grid[rr][c]` directly. Cspan-continuation slots are `None`, so the old direct scan fell through to a wrong ancestor cell, drawing horizontal rules through active span regions.
- **`_content` border condition**: Replaced `not _cspan_continues(r, c+1)` with `_has_vborder(r, c)` for rspan placeholder slots. The old check couldn't detect that two adjacent `None` slots share the same origin, resulting in a spurious internal `│` border inside the merged area.

## Test plan

- [ ] `test_flat_table_combined_cspan_rspan_no_internal_border` — new test covering the 2×2 case; asserts the continuation row has exactly 3 `│` borders and the row separator starts with `│` (no horizontal rule through the span)
- [ ] Full table test suite: `pytest tests/test_tables.py` — all 28 tests pass
- [ ] New demo entry `flat-table — single cell with :cspan: and :rspan: (2×2 block)` added to `tools/generate_demo_page.py`

Closes issue #2 from the open issue tracker (combined cspan+rspan origin resolution), and also addresses issue #3 (`_rspan_continues` for combined spans) which is required for the separator lines to be correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)