### PR TITLE
Fix versionadded/changed/deprecated body leaking into panel title

### DIFF
--- a/rich_rst/__init__.py
+++ b/rich_rst/__init__.py
@@ -109,16 +109,28 @@ class hlist_block(docutils.nodes.General, docutils.nodes.Body, docutils.nodes.El
 # ── Docutils directive classes for Sphinx-specific directives ─────────────────
 
 class _VersionDirective(docutils.parsers.rst.Directive):
-    """Handles ``.. versionadded::``, ``.. versionchanged::``, and ``.. deprecated::``."""
+    """Handles ``.. versionadded::``, ``.. versionchanged::``, and ``.. deprecated::``.
+
+    Matches Sphinx's signature: the version is the first argument and an
+    optional explanation is the second. ``final_argument_whitespace`` lets
+    the explanation span the indented line(s) immediately following the
+    directive (no blank line required), per the Python devguide form
+    ``.. versionchanged:: 2.0\\n   Added the *spam* parameter.``.
+    """
 
     required_arguments = 1
-    optional_arguments = 0
+    optional_arguments = 1
     final_argument_whitespace = True
     option_spec = {}
     has_content = True
 
     def run(self) -> List[docutils.nodes.Node]:
         node = versionmodified(type=self.name, version=self.arguments[0])
+        if len(self.arguments) > 1:
+            explanation = self.arguments[1]
+            inline_nodes, messages = self.state.inline_text(explanation, self.lineno)
+            node += docutils.nodes.paragraph(explanation, '', *inline_nodes)
+            node += messages
         if self.content:
             self.state.nested_parse(self.content, self.content_offset, node)
         return [node]

--- a/tests/test_sphinx_directives.py
+++ b/tests/test_sphinx_directives.py
@@ -75,6 +75,20 @@ def test_versionadded_no_body_no_crash(make_visitor):
     assert panels
 
 
+def test_versionadded_body_without_blank_line_not_in_title(make_visitor):
+    """Body content following the directive must not leak into the panel title.
+
+    Repro from rich-rst v2 feedback: when a ``versionadded`` directive has
+    body content on the next line (no blank separator), the body is
+    concatenated into the panel title rather than placed in the panel body,
+    producing ``"New in version 0.47 This was added recently."`` as the
+    title and an empty body row.
+    """
+    rst = ".. versionadded:: 0.47\n    This was added recently.\n"
+    panel = _first_panel(make_visitor, rst)
+    assert panel.title == "New in version 0.47"
+
+
 # ── versionchanged ────────────────────────────────────────────────────────────
 
 def test_versionchanged_produces_panel(make_visitor):


### PR DESCRIPTION
## Problem

When a `versionadded` / `versionchanged` / `deprecated` directive used the canonical Sphinx form (explanation on the indented line directly after the directive, no blank line between) the explanation was concatenated into the panel **title** and the panel **body** rendered empty.

```rst
.. versionadded:: 0.47
   This was added recently.
```

Before:

```
╭──────────────── New in version 0.47 This was added recently. ────────────────╮
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

After:

```
╭──────────────────────────── New in version 0.47 ─────────────────────────────╮
│ This was added recently.                                                     │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

## Root cause

`_VersionDirective` declared `required_arguments = 1, optional_arguments = 0` with `final_argument_whitespace = True`. Because docutils had no second argument to bind to, it folded the next indented line into the first (version) argument, producing a `version` attribute like `"0.47\nThis was added recently."` — which the visitor then placed in the panel title.

Sphinx's own `VersionChange` directive declares `optional_arguments = 1`, so the explanation is parsed as a second argument rather than being absorbed into the version string. See the [Python devguide](https://devguide.python.org/documentation/markup/) for the documented form.

## Fix

Match Sphinx's signature: `optional_arguments = 1`, and when present parse the second argument as inline text and attach it as a `paragraph` child of the `versionmodified` node. The existing visitor body-rendering path then places it inside the panel.

The blank-line-plus-indented-block form continues to work via `nested_parse` on `self.content`, so no existing usage breaks.