### PR TITLE
Remove trailing colons in admonition titles

### DIFF
--- a/rich_rst/__init__.py
+++ b/rich_rst/__init__.py
@@ -1998,12 +1998,16 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
             "versionchanged": ("restructuredtext.versionchanged", "bold cyan"),
             "deprecated": ("restructuredtext.deprecated", "bold yellow"),
             "deprecated-removed": ("restructuredtext.deprecated_removed", "bold red"),
+            "availability": ("restructuredtext.availability", "bold blue"),
+            "soft-deprecated": ("restructuredtext.soft_deprecated", "bold bright_yellow"),
         }
         panel_title_map = {
             "versionadded": f"New in version {version}",
             "versionchanged": f"Changed in version {version}",
             "deprecated": f"Deprecated since version {version}",
             "deprecated-removed": f"Deprecated since version {version}",
+            "availability": f"Available since version {version}",
+            "soft-deprecated": f"Soft Deprecated since version {version}",
         }
         # ``deprecated-removed`` relies on _DeprecatedRemovedDirective.run embedding
         # "(removed in <removed>)" into the version string, so this map produces
@@ -2014,13 +2018,17 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
             "versionchanged": f"Changed in v{version}",
             "deprecated": f"Deprecated in v{version}",
             "deprecated-removed": f"Deprecated in v{version}",
+            "availability": f"Available in v{version}",
+            "soft-deprecated": f"Soft Deprecated in v{version}",
         }
         # Severity glyphs match the admonition convention: ⚠ for warning-tone
-        # (deprecated → bold yellow), ✖ for danger-tone (deprecated-removed →
-        # bold red). versionadded/versionchanged stay glyphless.
+        # (deprecated/soft-deprecated → yellow), ✖ for danger-tone
+        # (deprecated-removed → bold red). versionadded/versionchanged/availability
+        # stay glyphless.
         glyph_map = {
             "deprecated": "⚠ ",
             "deprecated-removed": "✖ ",
+            "soft-deprecated": "⚠ ",
         }
         style_name, default_style = style_map.get(type_, ("restructuredtext.versionadded", "bold green"))
         style = self.console.get_style(style_name, default=default_style)
@@ -2205,10 +2213,19 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
 
     def visit_availability(self, node) -> None:
         version = node.get("version", "")
-        style = self.console.get_style("restructuredtext.availability", default="bold blue")
-        title = f"Available since version {version}" if version else "Availability"
-        body = self._render_admonition_body(node.children)
-        self.renderables.append(Panel(Group(*body) if body else "", title=title, style=style, border_style=style))
+        if version:
+            self._emit_version_directive("availability", version, node.children)
+        else:
+            # Defensive: the directive requires a version arg, but if missing
+            # we degrade to a plain admonition rather than rendering "v".
+            self._emit_admonition(
+                title="Availability",
+                glyph="",
+                style_name="restructuredtext.availability",
+                default_style="bold blue",
+                body_children=node.children,
+                panel_title="Availability",
+            )
         raise docutils.nodes.SkipChildren()
 
     def depart_availability(self, node) -> None:
@@ -2216,19 +2233,31 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
 
     def visit_soft_deprecated(self, node) -> None:
         version = node.get("version", "")
-        style = self.console.get_style("restructuredtext.soft_deprecated", default="bold bright_yellow")
-        title = f"Soft Deprecated since version {version}" if version else "Soft Deprecated"
-        body = self._render_admonition_body(node.children)
-        self.renderables.append(Panel(Group(*body) if body else "", title=title, style=style, border_style=style))
+        if version:
+            self._emit_version_directive("soft-deprecated", version, node.children)
+        else:
+            self._emit_admonition(
+                title="Soft Deprecated",
+                glyph="⚠ ",
+                style_name="restructuredtext.soft_deprecated",
+                default_style="bold bright_yellow",
+                body_children=node.children,
+                panel_title="Soft Deprecated",
+            )
         raise docutils.nodes.SkipChildren()
 
     def depart_soft_deprecated(self, node) -> None:
         pass
 
     def visit_impl_detail(self, node) -> None:
-        style = self.console.get_style("restructuredtext.impl_detail", default="bold magenta")
-        body = self._render_admonition_body(node.children)
-        self.renderables.append(Panel(Group(*body) if body else "", title="Implementation Detail", style=style, border_style=style))
+        self._emit_admonition(
+            title="Implementation Detail",
+            glyph="",
+            style_name="restructuredtext.impl_detail",
+            default_style="bold magenta",
+            body_children=node.children,
+            panel_title="Implementation Detail",
+        )
         raise docutils.nodes.SkipChildren()
 
     def depart_impl_detail(self, node) -> None:

--- a/rich_rst/__init__.py
+++ b/rich_rst/__init__.py
@@ -1941,19 +1941,19 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
         style_name: str,
         default_style: str,
         body_children: List[docutils.nodes.Node],
-        panel_title: Optional[str] = None,
     ) -> None:
         """Render an admonition in either ``panel`` or ``compact`` style.
 
-        ``title`` is the bare label (e.g. ``"Note"``); ``panel_title`` overrides
-        the title used in panel mode when it differs from ``f"{title}: "``.
+        ``title`` is the bare label (e.g. ``"Note"``) — used directly as the
+        panel title in panel mode and as the inline prefix label (followed by
+        ``": "``) in compact mode.
         """
         style = self.console.get_style(style_name, default=default_style)
         if self.admonition_style == "compact":
             self._emit_compact_admonition(title=title, glyph=glyph, style=style, body_children=body_children)
         else:
             self._emit_panel_admonition(
-                panel_title=panel_title if panel_title is not None else f"{title}: ",
+                panel_title=title,
                 style=style,
                 body_children=body_children,
             )
@@ -2074,18 +2074,15 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
         if node.children and isinstance(node.children[0], docutils.nodes.title):
             user_title = node.children[0].astext()
             body_children = node.children[1:]
-            panel_title = user_title
         else:
             user_title = "Admonition"
             body_children = node.children
-            panel_title = "Admonition: "
         self._emit_admonition(
             title=user_title,
             glyph="",
             style_name="restructuredtext.admonition",
             default_style="bold white",
             body_children=body_children,
-            panel_title=panel_title,
         )
         raise docutils.nodes.SkipChildren()
 
@@ -2096,7 +2093,6 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
             style_name="restructuredtext.attention",
             default_style="bold black on yellow",
             body_children=node.children,
-            panel_title="Attention: ",
         )
         raise docutils.nodes.SkipChildren()
 
@@ -2107,7 +2103,6 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
             style_name="restructuredtext.caution",
             default_style="red",
             body_children=node.children,
-            panel_title="Caution: ",
         )
         raise docutils.nodes.SkipChildren()
 
@@ -2118,7 +2113,6 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
             style_name="restructuredtext.danger",
             default_style="bold white on red",
             body_children=node.children,
-            panel_title="DANGER: ",
         )
         raise docutils.nodes.SkipChildren()
 
@@ -2129,7 +2123,6 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
             style_name="restructuredtext.error",
             default_style="bold red",
             body_children=node.children,
-            panel_title="ERROR: ",
         )
         raise docutils.nodes.SkipChildren()
 
@@ -2140,7 +2133,6 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
             style_name="restructuredtext.hint",
             default_style="yellow",
             body_children=node.children,
-            panel_title="Hint: ",
         )
         raise docutils.nodes.SkipChildren()
 
@@ -2151,7 +2143,6 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
             style_name="restructuredtext.important",
             default_style="bold blue",
             body_children=node.children,
-            panel_title="IMPORTANT: ",
         )
         raise docutils.nodes.SkipChildren()
 
@@ -2162,7 +2153,6 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
             style_name="restructuredtext.note",
             default_style="bold white",
             body_children=node.children,
-            panel_title="Note: ",
         )
         raise docutils.nodes.SkipChildren()
 
@@ -2173,7 +2163,6 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
             style_name="restructuredtext.tip",
             default_style="bold green",
             body_children=node.children,
-            panel_title="Tip: ",
         )
         raise docutils.nodes.SkipChildren()
 
@@ -2184,7 +2173,6 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
             style_name="restructuredtext.warning",
             default_style="bold yellow",
             body_children=node.children,
-            panel_title="Warning: ",
         )
         raise docutils.nodes.SkipChildren()
 
@@ -2204,7 +2192,6 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
             style_name="restructuredtext.seealso",
             default_style="bold white",
             body_children=node.children,
-            panel_title="See Also",
         )
         raise docutils.nodes.SkipChildren()
 
@@ -2224,7 +2211,6 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
                 style_name="restructuredtext.availability",
                 default_style="bold blue",
                 body_children=node.children,
-                panel_title="Availability",
             )
         raise docutils.nodes.SkipChildren()
 
@@ -2242,7 +2228,6 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
                 style_name="restructuredtext.soft_deprecated",
                 default_style="bold bright_yellow",
                 body_children=node.children,
-                panel_title="Soft Deprecated",
             )
         raise docutils.nodes.SkipChildren()
 
@@ -2256,7 +2241,6 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
             style_name="restructuredtext.impl_detail",
             default_style="bold magenta",
             body_children=node.children,
-            panel_title="Implementation Detail",
         )
         raise docutils.nodes.SkipChildren()
 

--- a/rich_rst/__init__.py
+++ b/rich_rst/__init__.py
@@ -13,7 +13,7 @@ import functools
 import os
 import re
 import threading
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, ClassVar, Dict, List, Literal, Optional, Tuple, Type, Union
 
 # Imports from rich_rst._vendor.docutils package for the parsing
 from rich_rst._vendor import docutils
@@ -1648,11 +1648,13 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
         show_line_numbers: Optional[bool] = False,
         guess_lexer: Optional[bool] = True,
         default_lexer: Optional[str] = "python",
+        admonition_style: Literal["panel", "compact"] = "panel",
     ) -> None:
         super().__init__(document)
         self.console: Console = console
         self.code_theme: Union[str, SyntaxTheme] = code_theme
         self.show_line_numbers: Optional[bool] = show_line_numbers
+        self.admonition_style: Literal["panel", "compact"] = admonition_style
         self.renderables: List[Any] = []
         self.superscript: Dict[int, Union[int, str, None]] = str.maketrans(
             "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ=+-*/×÷",
@@ -1906,6 +1908,7 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
             show_line_numbers=self.show_line_numbers,
             guess_lexer=self.guess_lexer,
             default_lexer=self.default_lexer,
+            admonition_style=self.admonition_style,
         )
         for child in children:
             child.walkabout(sub_visitor)
@@ -1925,106 +1928,276 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
             show_line_numbers=self.show_line_numbers,
             guess_lexer=self.guess_lexer,
             default_lexer=self.default_lexer,
+            admonition_style=self.admonition_style,
         )
         child.walkabout(sub_visitor)
         return sub_visitor.renderables
 
-    def visit_admonition(self, node) -> None:
-        style = self.console.get_style("restructuredtext.admonition", default="bold white")
-        # Generic admonition: first child is the user-supplied title node
-        if node.children and isinstance(node.children[0], docutils.nodes.title):
-            title = node.children[0].astext()
-            body_children = node.children[1:]
+    def _emit_admonition(
+        self,
+        *,
+        title: str,
+        glyph: str,
+        style_name: str,
+        default_style: str,
+        body_children: List[docutils.nodes.Node],
+        panel_title: Optional[str] = None,
+    ) -> None:
+        """Render an admonition in either ``panel`` or ``compact`` style.
+
+        ``title`` is the bare label (e.g. ``"Note"``); ``panel_title`` overrides
+        the title used in panel mode when it differs from ``f"{title}: "``.
+        """
+        style = self.console.get_style(style_name, default=default_style)
+        if self.admonition_style == "compact":
+            self._emit_compact_admonition(title=title, glyph=glyph, style=style, body_children=body_children)
         else:
-            title = "Admonition: "
-            body_children = node.children
+            self._emit_panel_admonition(
+                panel_title=panel_title if panel_title is not None else f"{title}: ",
+                style=style,
+                body_children=body_children,
+            )
+
+    def _emit_panel_admonition(self, *, panel_title: str, style: Style, body_children: List[docutils.nodes.Node]) -> None:
         body = self._render_admonition_body(body_children)
-        self.renderables.append(Panel(Group(*body) if body else "", title=title, style=style, border_style=style))
-        raise docutils.nodes.SkipChildren()
+        self.renderables.append(
+            Panel(Group(*body) if body else "", title=panel_title, style=style, border_style=style)
+        )
 
-    def visit_attention(self, node) -> None:
-        style = self.console.get_style("restructuredtext.attention", default="bold black on yellow")
-        body = self._render_admonition_body(node.children)
-        self.renderables.append(Panel(Group(*body) if body else "", title="Attention: ", style=style, border_style=style))
-        raise docutils.nodes.SkipChildren()
+    def _emit_compact_admonition(self, *, title: str, glyph: str, style: Style, body_children: List[docutils.nodes.Node]) -> None:
+        prefix = Text(f"{glyph}{title}: ", style=style, end="")
+        body = self._render_admonition_body(body_children)
+        self._prepend_styled_prefix(prefix, body)
 
-    def visit_caution(self, node) -> None:
-        style = self.console.get_style("restructuredtext.caution", default="red")
-        body = self._render_admonition_body(node.children)
-        self.renderables.append(Panel(Group(*body) if body else "", title="Caution: ", style=style, border_style=style))
-        raise docutils.nodes.SkipChildren()
+    def _prepend_styled_prefix(self, prefix: Text, body: List[Any]) -> None:
+        """Append ``prefix`` followed by ``body`` to ``self.renderables``.
 
-    def visit_danger(self, node) -> None:
-        style = self.console.get_style("restructuredtext.danger", default="bold white on red")
-        body = self._render_admonition_body(node.children)
-        self.renderables.append(Panel(Group(*body) if body else "", title="DANGER: ", style=style, border_style=style))
-        raise docutils.nodes.SkipChildren()
+        When the first body renderable is a :class:`Text` (the common case —
+        a paragraph), the prefix is merged into it via :meth:`Text.assemble`
+        so the prefix and first paragraph share a wrapped line. Otherwise
+        the prefix is emitted on its own line above the body. ``prefix`` is
+        expected to have ``end=""`` so paragraph spacing is governed by the
+        ``"\\n\\n"`` already baked into paragraph Texts by ``depart_paragraph``.
+        """
+        if not body:
+            prefix.append("\n\n")
+            self.renderables.append(prefix)
+            return
+        first = body[0]
+        if isinstance(first, Text):
+            merged = Text.assemble(prefix, first, end=first.end)
+            self.renderables.append(merged)
+            self.renderables.extend(body[1:])
+        else:
+            self.renderables.append(prefix)
+            self.renderables.extend(body)
 
-    def visit_error(self, node) -> None:
-        style = self.console.get_style("restructuredtext.error", default="bold red")
-        body = self._render_admonition_body(node.children)
-        self.renderables.append(Panel(Group(*body) if body else "", title="ERROR: ", style=style, border_style=style))
-        raise docutils.nodes.SkipChildren()
-
-    def visit_hint(self, node) -> None:
-        style = self.console.get_style("restructuredtext.hint", default="yellow")
-        body = self._render_admonition_body(node.children)
-        self.renderables.append(Panel(Group(*body) if body else "", title="Hint: ", style=style, border_style=style))
-        raise docutils.nodes.SkipChildren()
-
-    def visit_important(self, node) -> None:
-        style = self.console.get_style("restructuredtext.important", default="bold blue")
-        body = self._render_admonition_body(node.children)
-        self.renderables.append(Panel(Group(*body) if body else "", title="IMPORTANT: ", style=style, border_style=style))
-        raise docutils.nodes.SkipChildren()
-
-    def visit_note(self, node) -> None:
-        style = self.console.get_style("restructuredtext.note", default="bold white")
-        body = self._render_admonition_body(node.children)
-        self.renderables.append(Panel(Group(*body) if body else "", title="Note: ", style=style, border_style=style))
-        raise docutils.nodes.SkipChildren()
-
-    def visit_tip(self, node) -> None:
-        style = self.console.get_style("restructuredtext.tip", default="bold green")
-        body = self._render_admonition_body(node.children)
-        self.renderables.append(Panel(Group(*body) if body else "", title="Tip: ", style=style, border_style=style))
-        raise docutils.nodes.SkipChildren()
-
-    def visit_warning(self, node) -> None:
-        style = self.console.get_style("restructuredtext.warning", default="bold yellow")
-        body = self._render_admonition_body(node.children)
-        self.renderables.append(Panel(Group(*body) if body else "", title="Warning: ", style=style, border_style=style))
-        raise docutils.nodes.SkipChildren()
-
-    def visit_versionmodified(self, node) -> None:
-        type_ = node.get("type", "versionadded")
-        version = node.get("version", "")
+    def _emit_version_directive(self, type_: str, version: str, body_children: List[docutils.nodes.Node]) -> None:
         style_map = {
             "versionadded": ("restructuredtext.versionadded", "bold green"),
             "versionchanged": ("restructuredtext.versionchanged", "bold cyan"),
             "deprecated": ("restructuredtext.deprecated", "bold yellow"),
             "deprecated-removed": ("restructuredtext.deprecated_removed", "bold red"),
         }
-        title_map = {
+        panel_title_map = {
             "versionadded": f"New in version {version}",
             "versionchanged": f"Changed in version {version}",
             "deprecated": f"Deprecated since version {version}",
             "deprecated-removed": f"Deprecated since version {version}",
         }
+        # ``deprecated-removed`` relies on _DeprecatedRemovedDirective.run embedding
+        # "(removed in <removed>)" into the version string, so this map produces
+        # tags like ``[Deprecated in v0.9 (removed in 2.0)]``. Keep the formats
+        # in sync if that directive's version-string format ever changes.
+        short_title_map = {
+            "versionadded": f"Added in v{version}",
+            "versionchanged": f"Changed in v{version}",
+            "deprecated": f"Deprecated in v{version}",
+            "deprecated-removed": f"Deprecated in v{version}",
+        }
+        # Severity glyphs match the admonition convention: ⚠ for warning-tone
+        # (deprecated → bold yellow), ✖ for danger-tone (deprecated-removed →
+        # bold red). versionadded/versionchanged stay glyphless.
+        glyph_map = {
+            "deprecated": "⚠ ",
+            "deprecated-removed": "✖ ",
+        }
         style_name, default_style = style_map.get(type_, ("restructuredtext.versionadded", "bold green"))
-        title = title_map.get(type_, f"{type_} {version}")
         style = self.console.get_style(style_name, default=default_style)
-        body = self._render_admonition_body(node.children)
-        self.renderables.append(Panel(Group(*body) if body else "", title=title, style=style, border_style=style))
+
+        if self.admonition_style == "panel":
+            panel_title = panel_title_map.get(type_, f"{type_} {version}")
+            body = self._render_admonition_body(body_children)
+            self.renderables.append(
+                Panel(Group(*body) if body else "", title=panel_title, style=style, border_style=style)
+            )
+            return
+
+        short_title = short_title_map.get(type_, f"{type_} {version}")
+        glyph = glyph_map.get(type_, "")
+        body = self._render_admonition_body(body_children)
+        if not body:
+            tag = Text(f"{glyph}[{short_title}]", style=style, end="")
+            tag.append("\n\n")
+            self.renderables.append(tag)
+            return
+        # Bracket-collapse only when the body is a single paragraph. Adjacent
+        # paragraphs are coalesced into one trailing Text by visit_Text/depart_paragraph,
+        # so detect multi-paragraph bodies by checking for an internal "\n\n".
+        if len(body) == 1 and isinstance(body[0], Text):
+            inner = body[0].copy()
+            inner.rstrip()
+            if "\n\n" not in inner.plain:
+                bracketed = Text.assemble(
+                    Text(f"{glyph}[{short_title}: ", style=style),
+                    inner,
+                    Text("]", style=style),
+                    end="",
+                )
+                bracketed.append("\n\n")
+                self.renderables.append(bracketed)
+                return
+        # Multi-paragraph or structural body: fall back to title-prefix shape (no brackets).
+        prefix = Text(f"{glyph}{short_title}: ", style=style, end="")
+        self._prepend_styled_prefix(prefix, body)
+
+    def visit_admonition(self, node) -> None:
+        # Generic admonition: first child is the user-supplied title node
+        if node.children and isinstance(node.children[0], docutils.nodes.title):
+            user_title = node.children[0].astext()
+            body_children = node.children[1:]
+            panel_title = user_title
+        else:
+            user_title = "Admonition"
+            body_children = node.children
+            panel_title = "Admonition: "
+        self._emit_admonition(
+            title=user_title,
+            glyph="",
+            style_name="restructuredtext.admonition",
+            default_style="bold white",
+            body_children=body_children,
+            panel_title=panel_title,
+        )
+        raise docutils.nodes.SkipChildren()
+
+    def visit_attention(self, node) -> None:
+        self._emit_admonition(
+            title="Attention",
+            glyph="⚠ ",
+            style_name="restructuredtext.attention",
+            default_style="bold black on yellow",
+            body_children=node.children,
+            panel_title="Attention: ",
+        )
+        raise docutils.nodes.SkipChildren()
+
+    def visit_caution(self, node) -> None:
+        self._emit_admonition(
+            title="Caution",
+            glyph="⚠ ",
+            style_name="restructuredtext.caution",
+            default_style="red",
+            body_children=node.children,
+            panel_title="Caution: ",
+        )
+        raise docutils.nodes.SkipChildren()
+
+    def visit_danger(self, node) -> None:
+        self._emit_admonition(
+            title="DANGER",
+            glyph="✖ ",
+            style_name="restructuredtext.danger",
+            default_style="bold white on red",
+            body_children=node.children,
+            panel_title="DANGER: ",
+        )
+        raise docutils.nodes.SkipChildren()
+
+    def visit_error(self, node) -> None:
+        self._emit_admonition(
+            title="ERROR",
+            glyph="✖ ",
+            style_name="restructuredtext.error",
+            default_style="bold red",
+            body_children=node.children,
+            panel_title="ERROR: ",
+        )
+        raise docutils.nodes.SkipChildren()
+
+    def visit_hint(self, node) -> None:
+        self._emit_admonition(
+            title="Hint",
+            glyph="",
+            style_name="restructuredtext.hint",
+            default_style="yellow",
+            body_children=node.children,
+            panel_title="Hint: ",
+        )
+        raise docutils.nodes.SkipChildren()
+
+    def visit_important(self, node) -> None:
+        self._emit_admonition(
+            title="IMPORTANT",
+            glyph="",
+            style_name="restructuredtext.important",
+            default_style="bold blue",
+            body_children=node.children,
+            panel_title="IMPORTANT: ",
+        )
+        raise docutils.nodes.SkipChildren()
+
+    def visit_note(self, node) -> None:
+        self._emit_admonition(
+            title="Note",
+            glyph="",
+            style_name="restructuredtext.note",
+            default_style="bold white",
+            body_children=node.children,
+            panel_title="Note: ",
+        )
+        raise docutils.nodes.SkipChildren()
+
+    def visit_tip(self, node) -> None:
+        self._emit_admonition(
+            title="Tip",
+            glyph="",
+            style_name="restructuredtext.tip",
+            default_style="bold green",
+            body_children=node.children,
+            panel_title="Tip: ",
+        )
+        raise docutils.nodes.SkipChildren()
+
+    def visit_warning(self, node) -> None:
+        self._emit_admonition(
+            title="Warning",
+            glyph="⚠ ",
+            style_name="restructuredtext.warning",
+            default_style="bold yellow",
+            body_children=node.children,
+            panel_title="Warning: ",
+        )
+        raise docutils.nodes.SkipChildren()
+
+    def visit_versionmodified(self, node) -> None:
+        type_ = node.get("type", "versionadded")
+        version = node.get("version", "")
+        self._emit_version_directive(type_, version, node.children)
         raise docutils.nodes.SkipChildren()
 
     def depart_versionmodified(self, node) -> None:
         pass
 
     def visit_seealso(self, node) -> None:
-        style = self.console.get_style("restructuredtext.seealso", default="bold white")
-        body = self._render_admonition_body(node.children)
-        self.renderables.append(Panel(Group(*body) if body else "", title="See Also", style=style, border_style=style))
+        self._emit_admonition(
+            title="See Also",
+            glyph="",
+            style_name="restructuredtext.seealso",
+            default_style="bold white",
+            body_children=node.children,
+            panel_title="See Also",
+        )
         raise docutils.nodes.SkipChildren()
 
     def depart_seealso(self, node) -> None:
@@ -3777,6 +3950,7 @@ class RSTVisitor(docutils.nodes.SparseNodeVisitor):
                 show_line_numbers=self.show_line_numbers,
                 guess_lexer=self.guess_lexer,
                 default_lexer=self.default_lexer,
+                admonition_style=self.admonition_style,
             )
             for child in entry.children:
                 child.walkabout(sub_visitor)
@@ -4096,6 +4270,11 @@ class RestructuredText(JupyterMixin):
         Defaults to True for better compatibility with Python documentation.
     filename : Optional[str]
         A file name to use for error messages, useful for debugging purposes. Defaults to "<rst-document>"
+    admonition_style : str
+        How admonition directives (``note``, ``warning``, ``versionadded``, etc.) render.
+        ``"panel"`` (default) emits a bordered Rich :class:`~rich.panel.Panel` per directive.
+        ``"compact"`` collapses each directive to a styled inline title prefix, making the
+        output suitable for narrow contexts such as CLI ``--help`` panels.
     """
 
     def __init__(
@@ -4107,8 +4286,13 @@ class RestructuredText(JupyterMixin):
         guess_lexer: Optional[bool] = False,
         default_lexer: Optional[str] = "python",
         sphinx_compat: Optional[bool] = True,
-        filename: Optional[str] = "<rst-document>"
+        filename: Optional[str] = "<rst-document>",
+        admonition_style: Literal["panel", "compact"] = "panel",
     ) -> None:
+        if admonition_style not in ("panel", "compact"):
+            raise ValueError(
+                f"admonition_style must be 'panel' or 'compact', got {admonition_style!r}"
+            )
         self.markup: str = markup
         self.code_theme: Optional[Union[str, SyntaxTheme]] = code_theme
         self.show_line_numbers: Optional[bool] = show_line_numbers
@@ -4117,6 +4301,7 @@ class RestructuredText(JupyterMixin):
         self.default_lexer: Optional[str] = _validate_default_lexer_name(default_lexer)
         self.sphinx_compat: Optional[bool] = sphinx_compat
         self.filename: Optional[str] = filename
+        self.admonition_style: Literal["panel", "compact"] = admonition_style
 
     def render_to_string(self, width: Optional[int] = None, *, force_terminal: bool = False) -> str:
         """Render the RST markup to a plain string.
@@ -4218,6 +4403,7 @@ class RestructuredText(JupyterMixin):
             show_line_numbers=self.show_line_numbers,
             guess_lexer=self.guess_lexer,
             default_lexer=self.default_lexer,
+            admonition_style=self.admonition_style,
         )
         document.walkabout(visitor)
 

--- a/tests/test_admonitions.py
+++ b/tests/test_admonitions.py
@@ -6,26 +6,26 @@ attention, and the generic ``.. admonition::`` directive.
 Formatting contract
 -------------------
 Each named admonition directive produces exactly one ``Panel`` whose:
-* ``title`` is the exact string documented below (including the trailing
-  colon-space).
+* ``title`` is the exact string documented below (the bare label, no
+  trailing colon).
 * ``border_style`` encodes the severity of the admonition through specific
   colour and weight attributes.
 
 Named admonition titles and border styles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-+------------+------------+--------------------------+
-| directive  | title      | border_style             |
-+============+============+==========================+
-| note       | "Note: "   | bold white               |
-| warning    | "Warning: "| bold yellow              |
-| tip        | "Tip: "    | bold green               |
-| caution    | "Caution: "| red (no bold)            |
-| danger     | "DANGER: " | bold white on red        |
-| hint       | "Hint: "   | yellow (no bold)         |
-| important  | "IMPORTANT:"| bold blue               |
-| error      | "ERROR: "  | bold red                 |
-| attention  | "Attention:"| bold black on yellow    |
-+------------+------------+--------------------------+
++------------+--------------+--------------------------+
+| directive  | title        | border_style             |
++============+==============+==========================+
+| note       | "Note"       | bold white               |
+| warning    | "Warning"    | bold yellow              |
+| tip        | "Tip"        | bold green               |
+| caution    | "Caution"    | red (no bold)            |
+| danger     | "DANGER"     | bold white on red        |
+| hint       | "Hint"       | yellow (no bold)         |
+| important  | "IMPORTANT"  | bold blue                |
+| error      | "ERROR"      | bold red                 |
+| attention  | "Attention"  | bold black on yellow     |
++------------+--------------+--------------------------+
 """
 from rich.panel import Panel
 from rich.style import Style
@@ -72,31 +72,31 @@ def test_attention_produces_panel(make_visitor):
 # ── Exact panel titles ────────────────────────────────────────────────────────
 
 def test_note_panel_title(make_visitor):
-    assert _first_panel(make_visitor, "note").title == "Note: "
+    assert _first_panel(make_visitor, "note").title == "Note"
 
 def test_warning_panel_title(make_visitor):
-    assert _first_panel(make_visitor, "warning").title == "Warning: "
+    assert _first_panel(make_visitor, "warning").title == "Warning"
 
 def test_tip_panel_title(make_visitor):
-    assert _first_panel(make_visitor, "tip").title == "Tip: "
+    assert _first_panel(make_visitor, "tip").title == "Tip"
 
 def test_caution_panel_title(make_visitor):
-    assert _first_panel(make_visitor, "caution").title == "Caution: "
+    assert _first_panel(make_visitor, "caution").title == "Caution"
 
 def test_danger_panel_title(make_visitor):
-    assert _first_panel(make_visitor, "danger").title == "DANGER: "
+    assert _first_panel(make_visitor, "danger").title == "DANGER"
 
 def test_hint_panel_title(make_visitor):
-    assert _first_panel(make_visitor, "hint").title == "Hint: "
+    assert _first_panel(make_visitor, "hint").title == "Hint"
 
 def test_important_panel_title(make_visitor):
-    assert _first_panel(make_visitor, "important").title == "IMPORTANT: "
+    assert _first_panel(make_visitor, "important").title == "IMPORTANT"
 
 def test_error_panel_title(make_visitor):
-    assert _first_panel(make_visitor, "error").title == "ERROR: "
+    assert _first_panel(make_visitor, "error").title == "ERROR"
 
 def test_attention_panel_title(make_visitor):
-    assert _first_panel(make_visitor, "attention").title == "Attention: "
+    assert _first_panel(make_visitor, "attention").title == "Attention"
 
 
 # ── Border styles ─────────────────────────────────────────────────────────────

--- a/tests/test_admonitions_compact.py
+++ b/tests/test_admonitions_compact.py
@@ -73,6 +73,17 @@ def test_compact_versionadded_emits_no_panel(make_visitor):
     assert not any(isinstance(r, Panel) for r in visitor.renderables)
 
 
+@pytest.mark.parametrize("directive,arg", [
+    ("availability", "3.13"),
+    ("soft-deprecated", "3.13"),
+    ("impl-detail", ""),
+])
+def test_compact_new_directive_emits_no_panel(make_visitor, directive, arg):
+    rst = f".. {directive}:: {arg}\n\n   hello\n" if arg else f".. {directive}::\n\n   hello\n"
+    visitor = make_visitor(rst, admonition_style="compact")
+    assert not any(isinstance(r, Panel) for r in visitor.renderables)
+
+
 # ── Per-directive title prefixes ──────────────────────────────────────────────
 
 @pytest.mark.parametrize("directive,expected", [
@@ -158,6 +169,64 @@ def test_compact_deprecated_multiparagraph_body_has_glyph(render_text):
     assert "⚠ Deprecated in v1.0: First para." in out
     assert "Second para." in out
     assert "[Deprecated in v1.0: First para." not in out
+
+
+# ── availability / soft-deprecated / impl-detail (compact) ───────────────────
+
+@pytest.mark.parametrize("rst,expected", [
+    (".. availability:: 3.13\n", "[Available in v3.13]"),
+    (".. soft-deprecated:: 3.13\n", "⚠ [Soft Deprecated in v3.13]"),
+])
+def test_compact_new_version_directive_empty_body(render_text, rst, expected):
+    out = render_text(rst, admonition_style="compact")
+    assert expected in out
+
+
+def test_compact_availability_has_no_glyph(render_text):
+    """``availability`` is informational (like ``versionadded``); no severity glyph."""
+    out = render_text(".. availability:: 3.13\n", admonition_style="compact")
+    tag_lines = [ln for ln in out.splitlines() if "Available in v3.13" in ln]
+    assert tag_lines
+    for ln in tag_lines:
+        assert "⚠" not in ln
+        assert "✖" not in ln
+
+
+def test_compact_availability_single_paragraph_body(render_text):
+    rst = ".. availability:: 3.13\n\n   Only on Linux.\n"
+    out = render_text(rst, admonition_style="compact")
+    assert "[Available in v3.13: Only on Linux.]" in out
+
+
+def test_compact_soft_deprecated_single_paragraph_body_has_glyph(render_text):
+    rst = ".. soft-deprecated:: 3.13\n\n   Prefer :func:`new_api`.\n"
+    out = render_text(rst, admonition_style="compact")
+    assert "⚠ [Soft Deprecated in v3.13: Prefer " in out
+
+
+def test_compact_soft_deprecated_multiparagraph_body_has_glyph(render_text):
+    rst = ".. soft-deprecated:: 3.13\n\n   First para.\n\n   Second para.\n"
+    out = render_text(rst, admonition_style="compact")
+    assert "⚠ Soft Deprecated in v3.13: First para." in out
+    assert "Second para." in out
+    assert "[Soft Deprecated in v3.13: First para." not in out
+
+
+def test_compact_impl_detail_title_prefix(render_text):
+    """``impl-detail`` has no version; renders as a plain admonition prefix."""
+    rst = ".. impl-detail::\n\n   CPython-specific.\n"
+    out = render_text(rst, admonition_style="compact")
+    assert "Implementation Detail: CPython-specific." in out
+
+
+def test_compact_impl_detail_has_no_glyph(render_text):
+    rst = ".. impl-detail::\n\n   CPython-specific.\n"
+    out = render_text(rst, admonition_style="compact")
+    detail_lines = [ln for ln in out.splitlines() if "Implementation Detail" in ln]
+    assert detail_lines
+    for ln in detail_lines:
+        assert "⚠" not in ln
+        assert "✖" not in ln
 
 
 # ── Version directives (single-paragraph body → bracketed inline) ────────────

--- a/tests/test_admonitions_compact.py
+++ b/tests/test_admonitions_compact.py
@@ -1,0 +1,333 @@
+"""Tests for ``admonition_style="compact"`` rendering.
+
+Compact mode collapses each admonition directive to a styled inline title
+prefix (with optional severity glyph) instead of a bordered Rich Panel.
+This is intended for narrow-width contexts such as CLI ``--help`` panels.
+
+Compact rendering shape
+-----------------------
+Generic admonitions render as ``"<glyph><Title>: <body>"``. Severity glyphs:
+
++--------------+--------+
+| directive    | glyph  |
++==============+========+
+| warning      | "⚠ "   |
+| caution      | "⚠ "   |
+| attention    | "⚠ "   |
+| danger       | "✖ "   |
+| error        | "✖ "   |
+| important    | (none) |
+| note         | (none) |
+| hint         | (none) |
+| tip          | (none) |
+| seealso      | (none) |
+| admonition   | (none) |
++--------------+--------+
+
+Version directives (``versionadded``, ``versionchanged``, ``deprecated``,
+``deprecated-removed``) collapse to a bracketed inline tag using shortened
+phrasing — ``[Added in v0.47]`` / ``[Changed in v0.47]`` / ``⚠ [Deprecated in
+v0.47]`` / ``✖ [Deprecated in v0.47 (removed in 1.0)]``. ``deprecated`` gets
+the ⚠ glyph (warning-tone) and ``deprecated-removed`` gets ✖ (danger-tone);
+``versionadded``/``versionchanged`` stay glyphless. Empty bodies render as
+the bracketed tag alone; single-paragraph bodies render as ``[Added in v0.47:
+<body>]``; multi-paragraph or structural bodies fall back to the
+non-bracketed title-prefix shape.
+
+Panel mode (the default) is the byte-for-byte regression target covered by
+``test_admonitions.py`` and ``test_sphinx_directives.py``.
+"""
+import pytest
+from rich.panel import Panel
+
+from rich_rst import RestructuredText, _register_sphinx_directives
+
+
+@pytest.fixture(autouse=True)
+def ensure_sphinx_directives():
+    """Register Sphinx directives once before any test in this module runs."""
+    _register_sphinx_directives()
+
+
+# ── No panels in compact mode ────────────────────────────────────────────────
+
+@pytest.mark.parametrize("directive", [
+    "note", "warning", "tip", "caution", "danger",
+    "hint", "important", "error", "attention",
+])
+def test_compact_directive_emits_no_panel(make_visitor, directive):
+    rst = f".. {directive}::\n\n   hello\n"
+    visitor = make_visitor(rst, admonition_style="compact")
+    assert not any(isinstance(r, Panel) for r in visitor.renderables)
+
+
+def test_compact_seealso_emits_no_panel(make_visitor):
+    rst = ".. seealso::\n\n   Other docs.\n"
+    visitor = make_visitor(rst, admonition_style="compact")
+    assert not any(isinstance(r, Panel) for r in visitor.renderables)
+
+
+def test_compact_versionadded_emits_no_panel(make_visitor):
+    rst = ".. versionadded:: 0.47\n"
+    visitor = make_visitor(rst, admonition_style="compact")
+    assert not any(isinstance(r, Panel) for r in visitor.renderables)
+
+
+# ── Per-directive title prefixes ──────────────────────────────────────────────
+
+@pytest.mark.parametrize("directive,expected", [
+    ("note", "Note: hello"),
+    ("warning", "⚠ Warning: hello"),
+    ("tip", "Tip: hello"),
+    ("caution", "⚠ Caution: hello"),
+    ("danger", "✖ DANGER: hello"),
+    ("hint", "Hint: hello"),
+    ("important", "IMPORTANT: hello"),
+    ("error", "✖ ERROR: hello"),
+    ("attention", "⚠ Attention: hello"),
+])
+def test_compact_directive_title_prefix(render_text, directive, expected):
+    rst = f".. {directive}::\n\n   hello\n"
+    out = render_text(rst, admonition_style="compact")
+    assert expected in out
+
+
+def test_compact_seealso_title_prefix(render_text):
+    rst = ".. seealso::\n\n   Other docs.\n"
+    assert "See Also: Other docs." in render_text(rst, admonition_style="compact")
+
+
+def test_compact_generic_admonition_uses_user_title(render_text):
+    rst = ".. admonition:: Custom\n\n   body text.\n"
+    assert "Custom: body text." in render_text(rst, admonition_style="compact")
+
+
+# ── Multi-paragraph bodies ────────────────────────────────────────────────────
+
+def test_compact_note_multi_paragraph(render_text):
+    rst = ".. note::\n\n   First paragraph.\n\n   Second paragraph.\n"
+    out = render_text(rst, admonition_style="compact")
+    assert "Note: First paragraph." in out
+    assert "Second paragraph." in out
+
+
+# ── Version directives (empty body → bracketed tag) ──────────────────────────
+
+@pytest.mark.parametrize("rst,expected", [
+    (".. versionadded:: 0.47\n", "[Added in v0.47]"),
+    (".. versionchanged:: 0.47\n", "[Changed in v0.47]"),
+    (".. deprecated:: 0.47\n", "⚠ [Deprecated in v0.47]"),
+])
+def test_compact_version_directive_empty_body(render_text, rst, expected):
+    out = render_text(rst, admonition_style="compact")
+    assert expected in out
+
+
+def test_compact_deprecated_removed_empty_body(render_text):
+    """``deprecated-removed`` embeds the removal version in its version string
+    (per ``_DeprecatedRemovedDirective.run``), so the compact tag renders as
+    ``✖ [Deprecated in v<since> (removed in <removed>)]`` (danger-tone glyph
+    since this style is ``bold red``).
+    """
+    rst = ".. deprecated-removed:: 0.47 1.0\n"
+    out = render_text(rst, admonition_style="compact")
+    assert "✖ [Deprecated in v0.47 (removed in 1.0)]" in out
+
+
+def test_compact_versionadded_has_no_glyph(render_text):
+    """``versionadded``/``versionchanged`` are informational; no severity glyph."""
+    out = render_text(".. versionadded:: 0.47\n", admonition_style="compact")
+    tag_lines = [ln for ln in out.splitlines() if "Added in v0.47" in ln]
+    assert tag_lines
+    for ln in tag_lines:
+        assert "⚠" not in ln
+        assert "✖" not in ln
+
+
+def test_compact_deprecated_single_paragraph_body_has_glyph(render_text):
+    """Single-paragraph deprecated body keeps the ⚠ glyph outside the bracket."""
+    rst = ".. deprecated:: 1.0\n\n   Use :func:`new_thing` instead.\n"
+    out = render_text(rst, admonition_style="compact")
+    assert "⚠ [Deprecated in v1.0: Use " in out
+
+
+def test_compact_deprecated_multiparagraph_body_has_glyph(render_text):
+    """Multi-paragraph fallback (no brackets) still gets the ⚠ glyph prefix."""
+    rst = ".. deprecated:: 1.0\n\n   First para.\n\n   Second para.\n"
+    out = render_text(rst, admonition_style="compact")
+    assert "⚠ Deprecated in v1.0: First para." in out
+    assert "Second para." in out
+    assert "[Deprecated in v1.0: First para." not in out
+
+
+# ── Version directives (single-paragraph body → bracketed inline) ────────────
+
+def test_compact_versionadded_single_paragraph_body(render_text):
+    rst = ".. versionadded:: 2.0\n\n   Added support for widgets.\n"
+    out = render_text(rst, admonition_style="compact")
+    assert "[Added in v2.0: Added support for widgets.]" in out
+
+
+def test_compact_versionchanged_single_paragraph_body(render_text):
+    rst = ".. versionchanged:: 2.0\n\n   Now accepts a dict.\n"
+    out = render_text(rst, admonition_style="compact")
+    assert "[Changed in v2.0: Now accepts a dict.]" in out
+
+
+# ── Version directives (multi-paragraph body → fallback shape) ───────────────
+
+def test_compact_versionadded_multiparagraph_falls_back(render_text):
+    rst = ".. versionadded:: 2.0\n\n   First para.\n\n   Second para.\n"
+    out = render_text(rst, admonition_style="compact")
+    # Falls back to non-bracketed title-prefix shape.
+    assert "Added in v2.0: First para." in out
+    assert "Second para." in out
+    # The bracketed inline shape must NOT be used for multi-paragraph bodies.
+    assert "[Added in v2.0: First para." not in out
+
+
+# ── Default mode is still panel ───────────────────────────────────────────────
+
+def test_default_mode_still_emits_panel(make_visitor):
+    """Regression: omitting admonition_style preserves panel-mode output."""
+    rst = ".. note::\n\n   hello\n"
+    visitor = make_visitor(rst)
+    assert any(isinstance(r, Panel) for r in visitor.renderables)
+
+
+def test_explicit_panel_mode_emits_panel(make_visitor):
+    rst = ".. note::\n\n   hello\n"
+    visitor = make_visitor(rst, admonition_style="panel")
+    assert any(isinstance(r, Panel) for r in visitor.renderables)
+
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+def test_invalid_admonition_style_raises():
+    with pytest.raises(ValueError, match="admonition_style"):
+        RestructuredText("hello", admonition_style="bogus")
+
+
+# ── Inline markup is preserved in the compact body ───────────────────────────
+
+def test_compact_note_preserves_bold_inline(render_text):
+    """``**bold**`` inside a compact admonition body keeps its emphasis."""
+    rst = ".. note:: Use the **--force** flag.\n"
+    out = render_text(rst, admonition_style="compact")
+    assert "Note: Use the --force flag." in out
+
+
+def test_compact_warning_preserves_inline_code(render_text):
+    rst = ".. warning:: Avoid ``rm -rf /`` at all costs.\n"
+    out = render_text(rst, admonition_style="compact")
+    assert "⚠ Warning: Avoid " in out
+    assert "rm -rf /" in out
+    assert "at all costs." in out
+
+
+def test_compact_versionchanged_bracketed_preserves_inline_code(render_text):
+    rst = ".. versionchanged:: 2.0\n\n   Now accepts ``dict`` instead of ``list``.\n"
+    out = render_text(rst, admonition_style="compact")
+    assert "[Changed in v2.0: Now accepts " in out
+    assert "dict" in out and "list" in out
+
+
+# ── Important must not gain a glyph ──────────────────────────────────────────
+
+def test_compact_important_has_no_glyph(render_text):
+    """``important`` is informational (Sphinx convention); no severity glyph."""
+    rst = ".. important:: Back up first.\n"
+    out = render_text(rst, admonition_style="compact")
+    assert "IMPORTANT: Back up first." in out
+    # The output line containing the title must not start with ⚠ or ✖.
+    important_lines = [ln for ln in out.splitlines() if "IMPORTANT" in ln]
+    assert important_lines
+    for ln in important_lines:
+        assert "⚠" not in ln
+        assert "✖" not in ln
+
+
+# ── Compact admonitions inside containers (sub-visitor propagation) ──────────
+
+def test_compact_admonition_inside_table_cell(make_visitor):
+    """``admonition_style`` must propagate into the table-cell sub-visitor
+    (``_render_entry_content`` in ``__init__.py``). Inspect the table cell
+    directly because narrow cell widths can truncate the rendered output."""
+    from rich.table import Table as _Table
+    from rich.panel import Panel as _Panel
+    rst = (
+        ".. list-table::\n\n"
+        "   * - cell content\n\n"
+        "       .. note:: nested note text.\n"
+    )
+    visitor = make_visitor(rst, admonition_style="compact")
+    tables = [r for r in visitor.renderables if isinstance(r, _Table)]
+    assert tables, "list-table must produce a Rich Table"
+    cell_texts = []
+    for col in tables[0].columns:
+        for cell in col._cells:
+            assert not isinstance(cell, _Panel), "compact mode must not produce a Panel inside a table cell"
+            for sub in getattr(cell, "renderables", [cell]):
+                assert not isinstance(sub, _Panel), "compact mode must not produce a Panel inside a cell Group"
+                if hasattr(sub, "plain"):
+                    cell_texts.append(sub.plain)
+    joined = "\n".join(cell_texts)
+    assert "Note: nested note text." in joined
+
+
+def test_compact_admonition_inside_list_item(render_text):
+    """A compact admonition under a bullet item uses the just-merged
+    ``depart_paragraph`` list-item branch (commit 130ffcc) without breaking."""
+    rst = (
+        "* item one\n\n"
+        "  .. note:: nested in a bullet.\n\n"
+        "* item two\n"
+    )
+    out = render_text(rst, admonition_style="compact")
+    assert "Note: nested in a bullet." in out
+    assert "item one" in out and "item two" in out
+
+
+def test_compact_note_with_only_a_code_block(render_text):
+    """When the body's first renderable is non-Text (e.g. only a code block),
+    the prefix is emitted on its own line above the body."""
+    rst = (
+        ".. note::\n\n"
+        "   .. code-block:: python\n\n"
+        "      print('hi')\n"
+    )
+    out = render_text(rst, admonition_style="compact")
+    assert "Note: " in out
+    assert "print" in out and "hi" in out
+
+
+# ── Panel-mode title regression pins ──────────────────────────────────────────
+
+def test_panel_mode_seealso_title_has_no_trailing_colon(make_visitor):
+    """Existing tests assert ``"See Also"`` (no colon-space). Pin it here so an
+    accidental "fix" to match the other admonitions' ``"X: "`` convention fails."""
+    from rich.panel import Panel as _Panel
+    rst = ".. seealso::\n\n   Other docs.\n"
+    visitor = make_visitor(rst)
+    panels = [r for r in visitor.renderables if isinstance(r, _Panel)]
+    assert panels
+    assert panels[0].title == "See Also"
+
+
+# ── Integration: vertical density win at narrow widths ───────────────────────
+
+def test_compact_stacked_admonitions_save_lines():
+    """Compact rendering of stacked admonitions must use far fewer lines than panels."""
+    rst = (
+        ".. note:: This is important context.\n\n"
+        ".. warning:: Be careful here.\n\n"
+        ".. versionadded:: 0.47\n"
+    )
+    panel_lines = RestructuredText(rst, admonition_style="panel").render_to_string(width=68).splitlines()
+    compact_lines = RestructuredText(rst, admonition_style="compact").render_to_string(width=68).splitlines()
+    panel_nonblank = [ln for ln in panel_lines if ln.strip()]
+    compact_nonblank = [ln for ln in compact_lines if ln.strip()]
+    # Three short content lines in compact mode.
+    assert len(compact_nonblank) == 3, compact_lines
+    # Panel mode produces many more lines (panel borders + padding × 3 directives).
+    assert len(panel_nonblank) >= 9, panel_lines

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -933,7 +933,7 @@ def test_empty_body_rendering(render_text):
    Minimal content.
 """
     out = render_text(rst)
-    assert "Note:" in out, "Note admonition must render with 'Note:' panel title"
+    assert "Note" in out, "Note admonition must render with 'Note' panel title"
     assert "Minimal content" in out, "Admonition body must be visible"
 
 
@@ -972,7 +972,7 @@ def test_admonition_with_nested_lists_and_code(render_text):
       safe_function()
 """
     out = render_text(rst)
-    assert "Warning:" in out, "Warning admonition must render with 'Warning:' panel title"
+    assert "Warning" in out, "Warning admonition must render with 'Warning' panel title"
     assert "important information" in out, "Warning body must be visible"
 
 


### PR DESCRIPTION
Stacked on top of #55. Merge that first to see the smaller diff.

This PR just removes the trailing colons in the titles. I think the original intent was that there was going to be more text after the colon, but it didn't pan out? 

Before:
<img width="492" height="79" alt="Screenshot 2026-05-14 at 8 09 11 PM" src="https://github.com/user-attachments/assets/5a88a7b7-2cd2-4cfe-bacd-aca0c535ac31" />

After:
<img width="485" height="74" alt="Screenshot 2026-05-14 at 8 09 29 PM" src="https://github.com/user-attachments/assets/cabec943-2f05-49d2-b4d4-f3a97b6edc6c" />
