### PR TITLE
Include custom fixtures in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include tests/conftest.py


### PR DESCRIPTION
## 📑 Description

Running the tests requires the custom pytest fixtures defined in `tests/conftest.py`.  Setuptools includes most test files by default, but not that one.  Include it in the sdist via `MANIFEST.in` so that the tests can be run from the sdist.

## ✅ Checks

I don't think any of these apply, but let me know if I missed anything.

- [ ] My pull request adheres to the code style of this project if any
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed if any